### PR TITLE
Check plan has changes before apply

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -12,6 +12,9 @@ on:
       runner:
         required: true
         type: string
+      deploy_on:
+        type: string
+        default: 'refs/heads/main'
       working_directory:
         type: string
       project_id:
@@ -126,7 +129,7 @@ jobs:
         echo '```' >> $GITHUB_STEP_SUMMARY
 
   run_terraform:
-    if: github.ref == 'refs/heads/main' && needs.terraform_plan.outputs.exitcode == 2
+    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.exitcode == 2
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -81,21 +81,20 @@ jobs:
         shell: bash
 
     outputs:
-      exitcode: ${{ steps.plan.outputs.exitcode }}
+      planHasChanges: ${{ steps.plan.outputs.planHasChanges }}
 
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3
 
-    # Node is required for terraform_wrapper
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      # Change to v2.1.0 when released. We require the below fix:
+      # https://github.com/hashicorp/setup-terraform/pull/125
+      uses: hashicorp/setup-terraform@78ea3ac2fbe8fe4dab277d1cbd1e6435a91a49cc
+      with:
+        terraform_wrapper: false
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v0
@@ -137,12 +136,14 @@ jobs:
         terraform plan ${{inputs.terraform_options}} -input=false -no-color -detailed-exitcode | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
         exitcode=$?
         echo '```' >> $GITHUB_STEP_SUMMARY
-        if [[ $exitcode > 0 && $exitcode != 2 ]]; then
+        if [[ $exitcode == 2 ]]; then
+          echo '::set-output name=planHasChanges::true'
+        elif [[ $exitcode > 0 ]]; then
           exit $exitcode
         fi
 
   run_terraform:
-    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.exitcode == '2'
+    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.planHasChanges == 'true'
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -125,13 +125,21 @@ jobs:
     - name: Terraform Plan
       id: plan
       working-directory: ${{ inputs.working_directory }}
+      # Terraform will return exit code 2 when there are changes with -detailed-exitcode
+      # Using default bash shell includes -e which exits script on non-0 exit codes
+      # Override bash shell to allow other exit codes and check manually
+      shell: bash {0} -o pipefail
       run: |
         if [ "${{inputs.terraform_workspace}}" != "" ]; then
           terraform workspace select ${{inputs.terraform_workspace}}
         fi
         echo '```' >> $GITHUB_STEP_SUMMARY
         terraform plan ${{inputs.terraform_options}} -input=false -no-color -detailed-exitcode | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
+        exitcode=$?
         echo '```' >> $GITHUB_STEP_SUMMARY
+        if [ $exitcode > 0 && $exitcode != 2 ]; then
+          exit $exitcode
+        fi
 
   run_terraform:
     if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.exitcode == 2

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -142,7 +142,7 @@ jobs:
         fi
 
   run_terraform:
-    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.exitcode == 2
+    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.exitcode == '2'
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -126,7 +126,7 @@ jobs:
       working-directory: ${{ inputs.working_directory }}
       # Terraform will return exit code 2 when there are changes with -detailed-exitcode
       # Using default bash shell includes -e which exits script on non-0 exit codes
-      # Override bash shell to allow other exit codes and check manually
+      # Override bash shell to allow other exit codes and check manually for code 2
       shell: bash {0} -o pipefail
       run: |
         if [ "${{inputs.terraform_workspace}}" != "" ]; then
@@ -136,14 +136,15 @@ jobs:
         terraform plan ${{inputs.terraform_options}} -input=false -no-color -detailed-exitcode | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
         exitcode=$?
         echo '```' >> $GITHUB_STEP_SUMMARY
-        if [[ $exitcode == 2 ]]; then
+        if [[ $exitcode -eq 2 ]]; then
           echo '::set-output name=planHasChanges::true'
-        elif [[ $exitcode > 0 ]]; then
+        else
           exit $exitcode
         fi
 
   run_terraform:
-    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.planHasChanges == 'true'
+    #if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.planHasChanges == 'true'
+    if: needs.terraform_plan.outputs.planHasChanges == 'true'
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         echo 'Run format check' | tee -a $GITHUB_STEP_SUMMARY
         terraform fmt -check -no-color || { echo '
-        FAILURE! The above files are not properly formatted. 
+        FAILURE! The above files are not properly formatted.
         Run `terraform fmt` in ${{inputs.working_directory}}, commit the changed files and push to fix the issue' | tee -a $GITHUB_STEP_SUMMARY ; exit 1; }
 
   terraform_plan:
@@ -77,6 +77,9 @@ jobs:
       run:
         shell: bash
 
+    output:
+      exitcode: ${{ steps.plan.outputs.exitcode }}
+
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
@@ -85,9 +88,7 @@ jobs:
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
-      with:
-        terraform_wrapper: false
-    
+
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v0
       with:
@@ -114,17 +115,18 @@ jobs:
       run: terraform init
 
     - name: Terraform Plan
+      id: plan
       working-directory: ${{ inputs.working_directory }}
       run: |
         if [ "${{inputs.terraform_workspace}}" != "" ]; then
           terraform workspace select ${{inputs.terraform_workspace}}
         fi
         echo '```' >> $GITHUB_STEP_SUMMARY
-        terraform plan ${{inputs.terraform_options}} -input=false -no-color | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
+        terraform plan ${{inputs.terraform_options}} -input=false -no-color -detailed-exitcode | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-  
+
   run_terraform:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.terraform_plan.outputs.exitcode == 2
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}
@@ -145,7 +147,7 @@ jobs:
       uses: hashicorp/setup-terraform@v2
       with:
         terraform_wrapper: false
-    
+
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v0
       with:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -80,7 +80,7 @@ jobs:
       run:
         shell: bash
 
-    output:
+    outputs:
       exitcode: ${{ steps.plan.outputs.exitcode }}
 
     steps:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -136,8 +136,7 @@ jobs:
         echo '```' >> $GITHUB_STEP_SUMMARY
 
   run_terraform:
-    #if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.planHasChanges == 'true'
-    if: needs.terraform_plan.outputs.exitcode == '2'
+    if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.exitcode == '2'
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -80,8 +80,8 @@ jobs:
       run:
         shell: bash
 
-    outputs:
-      planHasChanges: ${{ steps.plan.outputs.planHasChanges }}
+    output:
+      exitcode: ${{ steps.plan.outputs.exitcode }}
 
     steps:
     # Checkout the repository to the GitHub Actions runner
@@ -93,8 +93,6 @@ jobs:
       # Change to v2.1.0 when released. We require the below fix:
       # https://github.com/hashicorp/setup-terraform/pull/125
       uses: hashicorp/setup-terraform@78ea3ac2fbe8fe4dab277d1cbd1e6435a91a49cc
-      with:
-        terraform_wrapper: false
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v0
@@ -124,27 +122,17 @@ jobs:
     - name: Terraform Plan
       id: plan
       working-directory: ${{ inputs.working_directory }}
-      # Terraform will return exit code 2 when there are changes with -detailed-exitcode
-      # Using default bash shell includes -e which exits script on non-0 exit codes
-      # Override bash shell to allow other exit codes and check manually for code 2
-      shell: bash {0} -o pipefail
       run: |
         if [ "${{inputs.terraform_workspace}}" != "" ]; then
           terraform workspace select ${{inputs.terraform_workspace}}
         fi
         echo '```' >> $GITHUB_STEP_SUMMARY
         terraform plan ${{inputs.terraform_options}} -input=false -no-color -detailed-exitcode | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
-        exitcode=$?
         echo '```' >> $GITHUB_STEP_SUMMARY
-        if [[ $exitcode -eq 2 ]]; then
-          echo '::set-output name=planHasChanges::true'
-        else
-          exit $exitcode
-        fi
 
   run_terraform:
     #if: github.ref == inputs.deploy_on && needs.terraform_plan.outputs.planHasChanges == 'true'
-    if: needs.terraform_plan.outputs.planHasChanges == 'true'
+    if: needs.terraform_plan.outputs.exitcode == '2'
     needs: [terraform_check, terraform_plan]
     name: Terraform Apply
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -88,6 +88,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    # Node is required for terraform_wrapper
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -88,6 +88,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    # Node is required for terraform_wrapper
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       # Change to v2.1.0 when released. We require the below fix:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -137,7 +137,7 @@ jobs:
         terraform plan ${{inputs.terraform_options}} -input=false -no-color -detailed-exitcode | grep -v 'Refreshing state...' | tee -a $GITHUB_STEP_SUMMARY
         exitcode=$?
         echo '```' >> $GITHUB_STEP_SUMMARY
-        if [ $exitcode > 0 && $exitcode != 2 ]; then
+        if [[ $exitcode > 0 && $exitcode != 2 ]]; then
           exit $exitcode
         fi
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This workflow plans and applies terraform config to deploy to an environment.
 jobs:
   dev:
     name: Deploy to dev
-    permissions: 
+    permissions:
       id-token: write
       contents: read
     uses: kartverket/github-workflows/.github/workflows/run-terraform.yml@v2
@@ -50,14 +50,14 @@ jobs:
     steps:
       - name: set outputs with default values
         id: set-output
-        run: |    
+        run: |
           echo "::set-output name=workload_identity_provider::${{ env.WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}"
           echo "::set-output name=service_account::${{ env.WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT }}"
           echo "::set-output name=project_id::${{ env.PROJECT_ID }}"
   dev:
     name: Deploy to dev
     needs: setup-env
-    permissions: 
+    permissions:
       id-token: write
       contents: read
     uses: kartverket/github-workflows/.github/workflows/run-terraform.yml@v2
@@ -95,6 +95,7 @@ this role.
 | workload_identity_provider | string | X        | The ID of the provider to use for authentication. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`   |
 | service_account            | string | X        | The GCP service account connected to the identity pool that will be used by Terraform.                                                                                                                                         |
 | runner                     | string | X        | The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`.                                                                                                                                         |
+| deploy_on                  | string |          | Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/head/main`.                                                         |
 | working_directory          | string |          | The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository.                                                                                        |
 | project_id                 | string |          | The GCP Project ID to use as the "active project" when running Terraform. When deploying to Kubernetes, this must match the project in which the Kubernetes cluster is registered.                                             |
 | kubernetes_cluster         | string |          | An optional kubernetes cluster to authenticate to. Note that the project_id must match where the cluster is registered                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: kartverket/github-workflows/.github/workflows/run-terraform.yml@v2
+    uses: kartverket/github-workflows/.github/workflows/run-terraform.yml@v2.1
     with:
       runner: atkv1-dev
       environment: dev

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ provide an output that can be mapped to the arguments of the job.
 
 <details>
 <summary>Click here to see an example of this</summary>
-<code><pre>
-env:
+<code><pre>env:
   WORKLOAD_IDENTITY_FEDERATION_PROVIDER: X
   WORKLOAD_IDENTITY_FEDERATION_SERVICE_ACCOUNT: X
   PROJECT_ID: X
@@ -70,8 +69,7 @@ jobs:
       working_directory: terraform
       workload_identity_provider: ${{ needs.setup-env.outputs.workload_identity_provider }}
       service_account: ${{ needs.setup-env.outputs.service_account }}
-      project_id: ${{ needs.setup-env.outputs.project_id }}
-</pre></code>
+      project_id: ${{ needs.setup-env.outputs.project_id }}</pre></code>
 </details>
 
 ### Passing secrets to run-terraform


### PR DESCRIPTION
Merging this PR will do two things:

1. Apply will no longer run if the previous plan step identified no changes
2. Adds a `deploy_on` input to override the branch that is used for deplying. It also makes testing of deploy easier on other branches

`terraform_wrapper` is now required as we read the exitcode output set by the wrapper script. On-prem runners do not have node which the script requires so we install that too.