### PR TITLE
Add support for bucket selection

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -60,7 +60,7 @@ on:
         type: boolean
         default: true
       bucket:
-        description: "..."
+        description: "An optional Cloud Storage bucket to use."
         required: false
         type: string
         default: ''

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -85,10 +85,29 @@ jobs:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v0
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
+        project_id: ${{ inputs.project_id }}
+
+    - name: Generate terraform backend variables
+      if: inputs.bucket != ''
+      run: |
+        cat <<EOF >> backend.tfbackend
+        bucket="${{ inputs.bucket }}"
+        EOF
     
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: terraform init
+      run: |
+        if [ "${{ inputs.bucket }}" = "" ]; then
+          terraform init
+        else
+          terraform init -backend-config=backend.tfbackend
+        fi
 
     - name: Terraform Validate
       id: validate

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -85,22 +85,10 @@ jobs:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3
-
-    - name: Generate terraform backend variables
-      if: inputs.bucket != ''
-      run: |
-        cat <<EOF >> backend.tfbackend
-        bucket="${{ inputs.bucket }}"
-        EOF
     
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: |
-        if [ "${{ inputs.bucket }}" = "" ]; then
-          terraform init
-        else
-          terraform init -backend-config=backend.tfbackend
-        fi
+      run: terraform init
 
     - name: Terraform Validate
       id: validate

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: boolean
         default: true
+      bucket:
+        description: "..."
+        required: false
+        type: string
+        default: ''
 
 jobs:
   terraform_check:
@@ -81,13 +86,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
-
+    - name: Generate terraform backend variables
+      if: inputs.bucket != ''
+      run: |
+        cat <<EOF >> backend.tfbackend
+        bucket="${{ inputs.bucket }}"
+        EOF
+    
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: terraform init -backend=false
+      run: |
+        if [ "${{ inputs.bucket }}" = "" ]; then
+          terraform init
+        else
+          terraform init -backend-config=backend.tfbackend
+        fi
 
     - name: Terraform Validate
       id: validate
@@ -166,10 +179,22 @@ jobs:
         role: ${{ inputs.vault_role }}
         certb64: 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW02Z0F3SUJBZ0lRSHhRNCszNDQ1TFJDazN6ZlVUUENPekFOQmdrcWhraUc5dzBCQVFzRkFEQkwKTVJJd0VBWUtDWkltaVpQeUxHUUJHUllDYm04eEdEQVdCZ29Ka2lhSmsvSXNaQUVaRmdoemRHRjBhMkZ5ZERFYgpNQmtHQTFVRUF4TVNTMkZ5ZEhabGNtdGxkQ0JTYjI5MElFTkJNQjRYRFRFMk1ETXlNakUwTURJek0xb1hEVFEyCk1ETXlNakUwTVRJek0xb3dTekVTTUJBR0NnbVNKb21UOGl4a0FSa1dBbTV2TVJnd0ZnWUtDWkltaVpQeUxHUUIKR1JZSWMzUmhkR3RoY25ReEd6QVpCZ05WQkFNVEVrdGhjblIyWlhKclpYUWdVbTl2ZENCRFFUQ0NBU0l3RFFZSgpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFKSjBaMWExNEpYblkxSUptaDgweGgwSFhKZmZZZ2lXCjVFRGtxOUVFUXRPYk1SUlVDbm16aUlDQ3lPM3hLQUdqWEJ1aFowL21vVUJnUXFwbWtDSlIvQ1pubnNJMVZ6QVkKMHNPbWlRaFVNSVdCUzhDRkltVWNoTmJOREM1SzZYVStwNGZodWxFN0lPL3FTZDd3V2dNSFZLdUE5eVBvVFJsMwowaVpZdG5IcUlCb3dZS3dJVHBBSmpwME5hTmNIalY2TWVOdlBrR1RURk45S1MxcG53QjhZVnFVYUZXdDJGVDh1CjBSTE9kUUgyeFFva1l4YW1RRWNqaEFBSnlzVDdkK25YemRzYUEwYXQrYlNwUExxTURVOW5JZFpuRGc1TlgyY0oKcnNlRm5tWTJ3Q2NLL2tMUUpVSWxSQVQ0UHI5Y08rZDRvSytRTFFOaGZpVmxUa0RaZU1ISHhia0NBd0VBQWFObQpNR1F3RXdZSkt3WUJCQUdDTnhRQ0JBWWVCQUJEQUVFd0N3WURWUjBQQkFRREFnR0dNQThHQTFVZEV3RUIvd1FGCk1BTUJBZjh3SFFZRFZSME9CQllFRk5xNUhyME9mV3kzbWMvckxXUEZrMHpmSWhlck1CQUdDU3NHQVFRQmdqY1YKQVFRREFnRUFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJkdHFVbDdvWFFTYWxIWjh6Y2dRZllvZWVxTGNwRQp5RjhFUngwdnFQc0hmY2VnL0ZXZEhFUVh4TWtPN1JER1Fzb2NmTVZvR0FBT1R3VlFPTHZCNmg4MnhCRVozSjBqCjBGMWkvcSs0WEd2NjdvOW43Z2NLNUFGOVNhcy9MVFB4N3dqQjV2dS85TkxyRkE1eXgyUG1iRnpNNFZRcXkwZnQKd2loaTdxMlhoQlVYUGo0SEdhTVE2aE1CYkRhSVl0Z0ovWWlkTFpSeGZWQVpGVEN4UDlPcDZVR3d0Zi9DeHdPSQo5ZkxtaWIwUDZCWG9sR3h1eU5XdHU2K0Vxc1JtMGtvcE5jcDkyZWpiOGsyb3R4VWdRcGNoVzRwd2RLMWZ3azhECndVblY5emhTc2k5eVZGMVVRUDZRcEJCeFNDZE5PT3JSSEg0N1djZmF0VUg0SWhuQW9PS0VyUVpBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K'
 
+    - name: Generate terraform backend variables
+      if: inputs.bucket != ''
+      run: |
+        cat <<EOF >> backend.tfbackend
+        bucket="${{ inputs.bucket }}"
+        EOF
+    
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       id: init
-      run: terraform init
+      run: |
+        if [ "${{inputs.bucket}}" = "" ]; then
+          terraform init
+        else
+          terraform init -backend-config=backend.tfbackend
+        fi
 
     - name: Terraform Plan
       id: plan
@@ -357,9 +382,21 @@ jobs:
         name: plan-${{ inputs.environment }}.tfplan
         path: ${{ inputs.working_directory }}
 
+    - name: Generate terraform backend variables
+      if: inputs.bucket != ''
+      run: |
+        cat <<EOF >> backend.tfbackend
+        bucket="${{ inputs.bucket }}"
+        EOF
+    
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: terraform init
+      run: |
+        if [ "${{ inputs.bucket }}" = "" ]; then
+          terraform init
+        else
+          terraform init -backend-config=backend.tfbackend
+        fi
 
     - name: Run Terraform
       run: |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jobs:
       service_account: X
       project_id: X
       image_url: <registry>/<repository>:<tag>
+      bucket: X
 ```
 
 ### Passing env vars to run-terraform
@@ -121,6 +122,7 @@ this role.
 | terraform_options          | string  |          | Any additional terraform options to be passed to plan and apply. For example `-var-file=dev.tfvars`                                                                                                                            |
 | add_comment_on_pr          | boolean |          | Setting this to `false` disables the creation of comments with info of the Terraform run on Pull Requests. When `true` the `pull-request` permission is required to be set to `write`. Defaults to `true`.                     |
 | image_url                  | string |          | An optional parameter; however, it is required for binary attestation. The Docker image url must be of the form registry/repository:tag                                                                                                                            |
+| bucket                  | string |          | An optional Cloud Storage bucket.                                                                                                                             |
 
 ## attest-image
 


### PR DESCRIPTION
Det er ikke så rett frem for produkt-teamene å sette hvilken gcp bøtte som skal brukes når de bruker run-terraform.
La til muligheten for å velge hvilken gcp bucket som skal brukes i run-terraform workflowen. 