### PR TITLE
re-add missing tag

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Terraform Init
       run: |
         if [ "${{ inputs.bucket }}" = "" ]; then
-          terraform init
+          terraform init -backend=false
         else
           terraform init -backend-config=backend.tfbackend
         fi


### PR DESCRIPTION
Gikk litt fort i svingene når jeg la til støtte for valg av buckets, og fjernet da ved uhell "-backend=false" taggen fra terraform init: 
https://github.com/kartverket/github-workflows/pull/6/files#diff-882d89623c60bdf99696df82fc56b922afd55ef061a569686f63a6564e0f3520L90 
