### PR TITLE
Sanitize usage of terraform output

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -204,9 +204,9 @@ jobs:
  
         # 4. Sanitize string for when it is injected into js template string later
         # Sanitize ` into \`
-        STDOUT="${STDOUT//\`/'\\`'}"
+        STDOUT="${STDOUT//\`/'\\\\`'}"
         # Sanitize ${} into \${}
-        STDOUT="${STDOUT//\${/'\\${'}"
+        STDOUT="${STDOUT//\${/'\\\\${'}"
 
         # 5. Serialize into single-line string for transfer using outputs that only support single line
         STDOUT="${STDOUT//'%'/'%25'}"

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -303,6 +303,10 @@ jobs:
             commentBody += '\n' + jobBody;
           }
 
+          commentBody = commentBody
+            .replaceAll("%0A", "\n")
+            .replaceAll("%0D", "\n");
+
           if (id) {
             github.rest.issues.updateComment({
               comment_id: id,

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -204,9 +204,9 @@ jobs:
  
         # 4. Sanitize string for when it is injected into js template string later
         # Sanitize ` into \`
-        STDOUT="${STDOUT//\`/'\\\\`'}"
+        STDOUT="${STDOUT//\`/'\`'}"
         # Sanitize ${} into \${}
-        STDOUT="${STDOUT//\${/'\\\\${'}"
+        STDOUT="${STDOUT//\${/'\${'}"
 
         # 5. Serialize into single-line string for transfer using outputs that only support single line
         STDOUT="${STDOUT//'%'/'%25'}"
@@ -214,7 +214,7 @@ jobs:
         STDOUT="${STDOUT//$'\r'/'%0D'}"
 
         # 6. Write output 
-        echo "name=stdout::$STDOUT" >> $GITHUB_OUTPUT
+        echo "stdout=$STDOUT" >> $GITHUB_OUTPUT
 
     - name: Upload Plan Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -204,9 +204,9 @@ jobs:
  
         # 4. Sanitize string for when it is injected into js template string later
         # Sanitize ` into \`
-        STDOUT="${STDOUT//\`/'\`'}"
+        STDOUT="${STDOUT//\`/'\\`'}"
         # Sanitize ${} into \${}
-        STDOUT="${STDOUT//\${/'\${'}"
+        STDOUT="${STDOUT//\${/'\\${'}"
 
         # 5. Serialize into single-line string for transfer using outputs that only support single line
         STDOUT="${STDOUT//'%'/'%25'}"

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -201,14 +201,20 @@ jobs:
         ${STDOUT}
         \`\`\`
         EOF
+ 
+        # 4. Sanitize string for when it is injected into js template string later
+        # Sanitize ` into \`
+        STDOUT="${STDOUT//\`/'\`'}"
+        # Sanitize ${} into \${}
+        STDOUT="${STDOUT//\${/'\${'}"
 
-        # 4. Serialize into single-line string for transfer using outputs that only support single line
+        # 5. Serialize into single-line string for transfer using outputs that only support single line
         STDOUT="${STDOUT//'%'/'%25'}"
         STDOUT="${STDOUT//$'\n'/'%0A'}"
         STDOUT="${STDOUT//$'\r'/'%0D'}"
 
-        # 5. Write output 
-        echo "::set-output name=stdout::$STDOUT"
+        # 6. Write output 
+        echo "name=stdout::$STDOUT" >> $GITHUB_OUTPUT
 
     - name: Upload Plan Artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
- Removes JavaScript template string symbols from the plan output.
- Also fixes deprecation of set-output: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Adds newlines to comment output when creating comment on PR