### PR TITLE
Adds setup-env as needed job where WIF env is used

### DIFF
--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -155,7 +155,7 @@ jobs:
   check-github-security:
     name: Check Github Security Code Scanning
     if: ${{ always() }}
-    needs: [tfsec, trivy]
+    needs: [tfsec, trivy, setup-env]
     runs-on: ubuntu-latest
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -181,7 +181,7 @@ jobs:
 
   attest:
     name: Attest Github Security Code Scanning
-    needs: [tfsec, trivy, check-github-security]
+    needs: [tfsec, trivy, check-github-security, setup-env]
     runs-on: ubuntu-latest
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -508,7 +508,7 @@ jobs:
   attest-deploy:
     if: inputs.image_url != '' && (inputs.environment == 'dev' || inputs.environment == 'test')
     name: Attest deploy to environment
-    needs: [run_terraform]
+    needs: [run_terraform, setup-env]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Even though the previous jobs needs a specific job (`setup-env`), these are not carried through to a job which needs said job. As such, we have to add `setup-env` to needs for any job where WIF env vars are used.