### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ jobs:
       pull-requests: write
       # For fetching git repo
       contents: read
+      # For accessing repository
+      packages: write
     uses: kartverket/github-workflows/.github/workflows/run-terraform.yml@<release tag>
     with:
       runner: atkv1-dev
@@ -86,6 +88,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
+      packages: write
     uses: kartverket/github-workflows/.github/workflows/run-terraform.yml@v2.1
     with:
       runner: atkv1-dev


### PR DESCRIPTION
In order for the _attest-deploy_ job to work in _run-terraform.yml_ the reusable workflow needs to be given the permission "_packages: write_" when called.