### PR TITLE
run-terraform on workflow dispatch

### DIFF
--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -193,8 +193,9 @@ jobs:
       - name: Check for Critical and High Severity
         id: severity_check
         run: |
+          echo ${{github.ref}}
           severity_check=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high" or .rule.security_severity_level == "critical"))] | any') 
-          if [[ $severity_check == 'true' &&  $EVENT_NAME == 'pull_request' ]]
+          if [[ $severity_check == 'true' && $EVENT_NAME == 'pull_request' ]]
           then
             pr_number=$( echo $BRANCH | sed 's/\/.*//')
             echo "Error: High or critical vulnerabilities detected on pull-request. Go to the Code Scanning section of the Github Security-tab and search for 'is:open pr:$pr_number' to review these vulnerabilities.";
@@ -203,9 +204,9 @@ jobs:
           then
             echo "Error: High or critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
             exit 1;
-          elif [[ $severity_check == 'true' &&  $EVENT_NAME == 'workflow_dispatch']]
+          elif [[ $severity_check == 'true' && $EVENT_NAME == 'workflow_dispatch' ]]
           then
-            echo "Error: High or critical vulnerabilities detected on workflow dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
+            echo "Error: High or critical vulnerabilities detected on workflow-dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
             exit 1;
           else
             echo "Success! No high or critical code scanning alerts."

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -193,7 +193,6 @@ jobs:
       - name: Check for Critical and High Severity
         id: severity_check
         run: |
-          echo ${{github.ref}}
           severity_check=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high" or .rule.security_severity_level == "critical"))] | any') 
           if [[ $severity_check == 'true' && $EVENT_NAME == 'pull_request' ]]
           then

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -203,6 +203,10 @@ jobs:
           then
             echo "Error: High or critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
             exit 1;
+          elif [[ $severity_check == 'true' &&  $EVENT_NAME == 'workflow_dispatch']]
+          then
+            echo "Error: High or critical vulnerabilities detected on workflow dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
+            exit 1;
           else
             echo "Success! No high or critical code scanning alerts."
           fi

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -427,7 +427,7 @@ jobs:
   run_terraform:
     # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
     needs: [terraform_check, terraform_plan, setup-env]
-    if: github.ref == inputs.deploy_on && github.event_name == 'push' && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == inputs.deploy_on && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}


### PR DESCRIPTION
Previously `terraform apply` in the run_terraform job of run-terraform.yml only ran on push to a specified branch. 
Now `terraform apply` additionally runs on workflow-dispatch.
Note the check-github-security job in run-security-scans.yml had to be modified to incorporate workflow-dispatch as well.

Tested here: https://github.com/kartverket/shipwreck/actions/runs/3592501676