### PR TITLE
Forbedring run terraform

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -449,7 +449,8 @@ jobs:
 
     needs: [terraform_check, terraform_plan, setup-env]
 
-    if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') 
+    # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,8 +451,8 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-
-    if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') 
+    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -447,8 +447,8 @@ jobs:
     # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
     needs: [terraform_check, terraform_plan, setup-env]
-   # if: github.ref = 'heads/refs/'${{ inputs.deploy_on }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
-    if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == 'refs/heads/'inputs.deploy_on && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -445,8 +445,9 @@ jobs:
 
   run_terraform:
     # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
+    # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
     needs: [terraform_check, terraform_plan, setup-env]
-    if: github.ref == inputs.deploy_on && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref = 'heads/refs/'${{ inputs.deploy_on }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -117,12 +117,15 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+
+jobs:
   test:
     runs-on: ubuntu-latest
     steps:
      - name: Echo 
        run: |
-        echo ${{ github.ref_name }}
+#        echo ${{ github.ref_name }}
+         echo ${GITHUB_REF}
   setup-env:
     runs-on: ubuntu-latest
     outputs:
@@ -136,6 +139,7 @@ jobs:
           OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+
 
   terraform_check:
     needs: [setup-env]

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
      - name: Echo 
        run: |
-        echo ${{ github.ref }}
+        echo ${{ github.ref_name }}
   setup-env:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -449,7 +449,7 @@ jobs:
 
     needs: [terraform_check, terraform_plan, setup-env]
 
-    if: github.ref == format(‘refs/heads/{0}’, inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
      - name: Echo 
        run: |
-        echo ${{ github.ref_name }}
+        echo ${{ github}}
 
   
   setup-env:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -448,7 +448,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
     needs: [terraform_check, terraform_plan, setup-env]
    # if: github.ref = 'heads/refs/'${{ inputs.deploy_on }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
-    if: github.ref = 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -122,8 +122,9 @@ jobs:
     steps:
      - name: Echo 
        run: |
-#        echo ${{ github.ref_name }}
-         echo ${GITHUB_REF}
+        echo ${{ github.ref_name }}
+
+  
   setup-env:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -447,7 +447,7 @@ jobs:
     # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
     needs: [terraform_check, terraform_plan, setup-env]
-    if: github.ref == 'refs/heads/'inputs.deploy_on && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == 'refs/heads/'env.DEPLOY_ON && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -121,9 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: Echo 
-       run: |
-        echo ${{ github}}
-
+ #      run: |
+ #       echo ${{ github}}
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
   
   setup-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -117,8 +117,6 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-
-jobs:
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') 
+    if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -23,7 +23,7 @@ on:
         description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
         required: false
         type: string
-      working_directory:
+      working_directory: 
         description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
         required: false
         type: string
@@ -116,8 +116,6 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-
-  
   setup-env:
     runs-on: ubuntu-latest
     outputs:
@@ -131,7 +129,6 @@ jobs:
           OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-
 
   terraform_check:
     needs: [setup-env]

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -23,7 +23,6 @@ on:
         description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
         required: false
         type: string
-#        default: "refs/heads/main"
       working_directory:
         description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
         required: false
@@ -122,6 +121,7 @@ jobs:
     steps:
       - name: Echo 
         env:
+        
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
   
@@ -138,7 +138,10 @@ jobs:
           OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-
+      - name: Echo github context 
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
 
   terraform_check:
     needs: [setup-env]
@@ -447,14 +450,8 @@ jobs:
             }
 
   run_terraform:
-    # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
-    # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
-
     needs: [terraform_check, terraform_plan, setup-env]
     if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
-    #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
-    # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -447,7 +447,8 @@ jobs:
     # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
     needs: [terraform_check, terraform_plan, setup-env]
-    if: github.ref = 'heads/refs/'${{ inputs.deploy_on }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+   # if: github.ref = 'heads/refs/'${{ inputs.deploy_on }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref = 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.environment }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -117,6 +117,12 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+     - name: Echo 
+       run: |
+        echo ${{ github.ref }}
   setup-env:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -449,7 +449,7 @@ jobs:
 
     needs: [terraform_check, terraform_plan, setup-env]
 
-    if: github.ref == ${{ format(‘refs/heads/{0}’, inputs.deploy_on) }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    if: github.ref == format(‘refs/heads/{0}’, inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -123,9 +123,9 @@ jobs:
      - name: Echo 
  #      run: |
  #       echo ${{ github}}
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: echo "$GITHUB_CONTEXT"
   
   setup-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') 
+    if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') 
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -23,7 +23,7 @@ on:
         description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
         required: false
         type: string
-        default: "refs/heads/main"
+#        default: "refs/heads/main"
       working_directory:
         description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
         required: false
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || github.head_ref == inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
+    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -120,7 +120,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-     - name: Echo 
+      - name: Echo 
  #      run: |
  #       echo ${{ github}}
       env:

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -116,14 +116,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo 
-        env:
-        
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
+
   
   setup-env:
     runs-on: ubuntu-latest
@@ -138,10 +131,7 @@ jobs:
           OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
-      - name: Echo github context 
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
+
 
   terraform_check:
     needs: [setup-env]

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -121,11 +121,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo 
- #      run: |
- #       echo ${{ github}}
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
   
   setup-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -451,7 +451,7 @@ jobs:
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
 
     needs: [terraform_check, terraform_plan, setup-env]
-    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: ((github.ref == 'refs/head/main' || github.ref == 'refs/head/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') 
     #if: github.ref == format('refs/heads/{0}', inputs.deploy_on) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -446,8 +446,10 @@ jobs:
   run_terraform:
     # TODO We need to verify that env.DEPLOY_ON actually works. Seems to only work on main atm
     # changed from github.ref = inputs.deploy_on to github.ref = 'heads/refs/'${{ inputs.deploy_on }}
+
     needs: [terraform_check, terraform_plan, setup-env]
-    if: github.ref == 'refs/heads/'env.DEPLOY_ON && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+
+    if: github.ref == ${{ format(‘refs/heads/{0}’, inputs.deploy_on) }} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     # if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
     name: Terraform Apply or Destroy
     runs-on: ${{ inputs.runner }}


### PR DESCRIPTION
The developers are allowed now to write the branch name without the full path. 
Example: (master) instead of (refs/heads/master).
OPS To Ensure backwards compatibility both branch name and full path are accepted. 