### PR TITLE
[SKIP-906] Allow customization of RSS severity

### DIFF
--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -223,8 +223,8 @@ jobs:
           echo "$result_severity_check_critical";
           echo "$result_severity_check_error";
 
-          is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || echo "false")
-          is_critical_vuln_present=$([[ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ]] && echo "true" || echo "false")
+          is_high_vuln_present=$([[ "$result_severity_check_high" =~ [[a-zA-Z]] ]] && echo "true" || echo "false")
+          is_critical_vuln_present=$([[ "$result_severity_check_critical" =~ [[a-zA-Z]] || "$result_severity_check_error" =~ [[a-zA-Z]] ]] && echo "true" || echo "false")
 
           echo "is_high_vuln_present=$is_high_vuln_present" >> $GITHUB_OUTPUT
           echo "is_critical_vuln_present=$is_critical_vuln_present" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -231,8 +231,10 @@ jobs:
         id: severity_check
         run: |
           pr_number=$( echo $BRANCH | sed 's/\/.*//');
+          is_high_vuln_present=${{ steps.severity_check_outputs.outputs.is_high_vuln_present }}
+          is_critical_vuln_present=${{ steps.severity_check_outputs.outputs.is_critical_vuln_present }}
 
-          if [[ ${{ steps.severity_check_outputs.outputs.is_high_vuln_present == 'false' && steps.severity_check_outputs.outputs.is_critical_vuln_present == 'false' }} == 'true' ]]
+          if [[ $is_high_vuln_present == 'false' ||  $is_critical_vuln_present == 'false' ]]
           then
             echo "Success! No high or critical code scanning alerts.";
             exit 0;
@@ -256,7 +258,7 @@ jobs:
 
           elif [[ $ALLOW_SEVERITY_LEVEL == 'high' ]]
           then
-            if [[ ${{ steps.severity_check_outputs.outputs.is_critical_vuln_present }} == 'false' ]]
+            if [[ $is_critical_vuln_present == 'false' ]]
             then
               echo "Only high vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high.";
               exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -189,6 +189,43 @@ jobs:
             --keyversion="1"
           echo Attestation succeded
 
+  trivy-repo:
+    name: Trivy repo scan
+    if: inputs.trivy == true && github.event.pull_request.draft == false
+    needs: [setup-env]
+    runs-on: ubuntu-latest
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      packages: write
+      # required for authentication to GCP
+      id-token: write
+      actions: read
+      security-events: write
+    env:
+      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5
+        with:
+          scan-type: fs
+          format: sarif
+          output: trivy-results.sarif
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          timeout: 15m
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-results.sarif
+
   check-github-security:
     name: Check Github Security Code Scanning
     needs: [tfsec, trivy, setup-env]

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -216,6 +216,7 @@ jobs:
           pr_number=$( echo $BRANCH | sed 's/\/.*//');
 
           if [[ ${{ steps.severity_check_outputs.outputs.severity_check_high == 'false' && steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
+          then
             echo "Success! No high or critical code scanning alerts.";
             exit 0;
           fi

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -241,7 +241,7 @@ jobs:
           error_end_message="Go to the Code Scanning section of the Github Secuity tab to review these vulnerabilities."
           error_search_pr_message="Search for is:open pr:"$pr_number" to find PR related vulnerabilities."
 
-          if [[ $is_high_vuln_present == 'false' ||  $is_critical_vuln_present == 'false' ]]
+          if [[ $is_high_vuln_present == 'false' &&  $is_critical_vuln_present == 'false' ]]
           then
             echo "Success! No high or critical code scanning alerts.";
             exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -220,6 +220,9 @@ jobs:
           result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=critical")
           result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=error")
 
+          echo "$result_severity_check_critical";
+          echo "$result_severity_check_error";
+
           is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || echo "false")
           is_critical_vuln_present=$([[ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ]] && echo "true" || echo "false")
 

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -31,7 +31,7 @@ on:
         default: true
         type: boolean
       allow_severity_level:
-        description: 'A string which determines the highest level of severity the security scans can find while still succeeding workflows. Only "medium", "high" and "critical" values are allowed. Any Note that these values are case sensitive.'
+        description: 'A string which determines the highest level of severity the security scans can find while still succeeding workflows. Only "medium", "high" and "critical" values are allowed. Note that these values are case sensitive.'
         required: false
         default: medium
         type: string

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -234,7 +234,7 @@ jobs:
           is_high_vuln_present=${{ steps.severity_check_outputs.outputs.is_high_vuln_present }}
           is_critical_vuln_present=${{ steps.severity_check_outputs.outputs.is_critical_vuln_present }}
 
-          error_start_message="Error: Vulnerabilities were found of level "
+          error_start_message="Error: Vulnerabilities were found of level"
           error_end_message="Go to the Code Scanning section of the Github Secuity tab to review these vulnerabilities."
           error_search_pr_message="Search for is:open pr:"$pr_number" to find PR related vulnerabilities."
 
@@ -246,7 +246,7 @@ jobs:
 
           if [[ ${{ env.ALLOW_SEVERITY_LEVEL }} == 'none' ]]
           then
-            if [[ $EVENT_NAME == 'pull_request' ]]
+            if [[ ${{ env.EVENT_NAME }} == 'pull_request' ]]
             then
               echo ""$error_start_message" high or critical. "$error_end_message" "$error_search_pr_message"";
               exit 1;
@@ -263,7 +263,7 @@ jobs:
               exit 0;
             fi
 
-            if [[ $EVENT_NAME == 'pull_request' ]]
+            if [[ ${{ env.EVENT_NAME }} == 'pull_request' ]]
             then
               echo ""$error_start_message" critical. "$error_end_message" "$error_search_pr_message"";
               exit 1;
@@ -278,7 +278,7 @@ jobs:
             exit 0;
 
           else
-            echo "Input ALLOW_SEVERITY_LEVEL was not one of the known values, found "$ALLOW_SEVERITY_LEVEL". If you see this message, please contact SKIP.";
+            echo "Input ALLOW_SEVERITY_LEVEL was not one of the known values, found "${{ env.ALLOW_SEVERITY_LEVEL }}". If you see this message, please contact SKIP.";
             exit 1;
           fi
 

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -73,6 +73,10 @@ jobs:
     if: inputs.tfsec == true && github.event.pull_request.draft == false
     needs: [setup-env]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Set high and critical severity outputs
         id: severity_check_outputs
         run: |
-          severity_check_high=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}}& | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high"))] | any') 
+          severity_check_high=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high"))] | any') 
           severity_check_critical=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "critical"))] | any')
           echo "severity_check_high=$severity_check_high" >> $GITHUB_OUTPUT
           echo "severity_check_critical=$severity_check_critical" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Set high and critical severity outputs
         id: severity_check_outputs
         run: |
-          severity_check_high=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high"))] | any') 
+          severity_check_high=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}}& | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high"))] | any') 
           severity_check_critical=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "critical"))] | any')
           echo "severity_check_high=$severity_check_high" >> $GITHUB_OUTPUT
           echo "severity_check_critical=$severity_check_critical" >> $GITHUB_OUTPUT
@@ -243,7 +243,7 @@ jobs:
 
           elif [[ $ALLOW_SEVERITY_LEVEL == 'high' ]]
           then
-            if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical }} == 'true' ]]
+            if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical }} == 'false' ]]
             then
               echo "Only high vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high.";
               exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -216,9 +216,9 @@ jobs:
           auth_header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
           base_url="https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{ github.ref }}&state=open"
 
-          result_severity_check_high=$(curl -s -H "$content_header" -H "$auth_header" "${$base_url}&severity=high")
-          result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "${$base_url}&severity=critical")
-          result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${$base_url}&severity=error")
+          result_severity_check_high=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=high")
+          result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=critical")
+          result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=error")
 
           is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || echo "false")
           is_critical_vuln_present=$([ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ] && echo "true" || echo "false")

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -31,9 +31,9 @@ on:
         default: true
         type: boolean
       allow_severity_level:
-        description: 'A string which determines the level of severity the security scans can find while still succeeding workflows. Only "none", "high" and "critical" values are allowed. Note that these values are case sensitive. Note also that a severity level of "none" still allows medium/low severities, as these are not considered dangerous.'
+        description: 'A string which determines the highest level of severity the security scans can find while still succeeding workflows. Only "medium", "high" and "critical" values are allowed. Any Note that these values are case sensitive.'
         required: false
-        default: none
+        default: medium
         type: string
 
 env:
@@ -63,9 +63,9 @@ jobs:
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
       - name: Check severity level
-        if: inputs.allow_severity_level != 'none' && inputs.allow_severity_level != 'high' && inputs.allow_severity_level != 'critical'
+        if: inputs.allow_severity_level != 'medium' && inputs.allow_severity_level != 'high' && inputs.allow_severity_level != 'critical'
         run: |
-          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'none'. Found: "$ALLOW_SEVERITY_LEVEL".";
+          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'medium'. Found: "$ALLOW_SEVERITY_LEVEL".";
           exit 1;
 
   tfsec:
@@ -243,7 +243,7 @@ jobs:
             exit 0;
           fi
 
-          if [[ ${{ env.ALLOW_SEVERITY_LEVEL }} == 'none' ]]
+          if [[ ${{ env.ALLOW_SEVERITY_LEVEL }} == 'medium' ]]
           then
             if [[ ${{ env.EVENT_NAME }} == 'pull_request' ]]
             then

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -187,8 +187,12 @@ jobs:
 
   check-github-security:
     name: Check Github Security Code Scanning
-    if: ${{ success() }}
     needs: [tfsec, trivy, setup-env]
+    # Always runs after tfsec and trivy, but not if they failed or got cancelled
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -217,14 +217,14 @@ jobs:
         with:
           scan-type: fs
           format: sarif
-          output: trivy-results.sarif
+          output: trivy-fs-results.sarif
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           timeout: 15m
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: trivy-results.sarif
+          sarif_file: trivy-fs-results.sarif
 
   check-github-security:
     name: Check Github Security Code Scanning

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -33,7 +33,7 @@ on:
       allow_severity_level:
         description: 'A string which determines the level of severity the security scans can find while still succeeding workflows. Only "not_allowed", "high" and "critical" values are allowed. Note that these values are case sensitive.'
         required: false
-        default: "not_allowed"
+        default: not_allowed
         type: string
 
 env:
@@ -46,7 +46,7 @@ env:
   BRANCH: ${{ github.ref_name }}
   HEAD_REF: ${{ github.head_ref }}
   EVENT_NAME: ${{ github.event_name }}
-  ALLOW_SEVERITY_LEVEL: ${{ inputs.allow_severity_levels }}
+  ALLOW_SEVERITY_LEVEL: ${{ inputs.allow_severity_level }}
 
 jobs:
   setup-env:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -71,6 +71,7 @@ jobs:
   tfsec:
     name: TFSec
     if: inputs.tfsec == true && github.event.pull_request.draft == false
+    needs: [setup-env]
     runs-on: ubuntu-latest
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -234,6 +234,10 @@ jobs:
           is_high_vuln_present=${{ steps.severity_check_outputs.outputs.is_high_vuln_present }}
           is_critical_vuln_present=${{ steps.severity_check_outputs.outputs.is_critical_vuln_present }}
 
+          error_start_message="Error: Vulnerabilities were found of level "
+          error_end_message="Go to the Code Scanning section of the Github Secuity tab to review these vulnerabilities."
+          error_search_pr_message="Search for is:open pr:"$pr_number" to find PR related vulnerabilities."
+
           if [[ $is_high_vuln_present == 'false' ||  $is_critical_vuln_present == 'false' ]]
           then
             echo "Success! No high or critical code scanning alerts.";
@@ -244,15 +248,10 @@ jobs:
           then
             if [[ $EVENT_NAME == 'pull_request' ]]
             then
-              echo "Error: High or critical vulnerabilities detected on pull-request. Go to the Code Scanning section of the Github Security-tab and search for 'is:open pr:$pr_number' to review these vulnerabilities.";
+              echo ""$error_start_message" high or critical. "$error_end_message" "$error_search_pr_message"";
               exit 1;
-            elif [[ ($BRANCH == 'main' || $BRANCH == 'master')]]
-            then
-              echo "Error: High or critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
-              exit 1;
-            elif [[ $EVENT_NAME == 'workflow_dispatch' ]]
-            then
-              echo "Error: High or critical vulnerabilities detected on workflow-dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
+            else
+              echo ""$error_start_message" high or critical found on branch "$BRANCH". $error_end_message";
               exit 1;
             fi
 
@@ -266,15 +265,10 @@ jobs:
 
             if [[ $EVENT_NAME == 'pull_request' ]]
             then
-              echo "Error: Critical vulnerabilities detected on pull-request. Go to the Code Scanning section of the Github Security-tab and search for 'is:open pr:$pr_number' to review these vulnerabilities.";
+              echo ""$error_start_message" critical. "$error_end_message" "$error_search_pr_message"";
               exit 1;
-            elif [[ ($BRANCH == 'main' || $BRANCH == 'master')]]
-            then
-              echo "Error: Critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
-              exit 1;
-            elif [[ $EVENT_NAME == 'workflow_dispatch' ]]
-            then
-              echo "Error: Critical vulnerabilities detected on workflow-dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
+            else
+              echo ""$error_start_message" critical found on "$BRANCH" branch. $error_end_message";
               exit 1;
             fi
 
@@ -282,6 +276,7 @@ jobs:
           then
             echo "High or critical vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to critical.";
             exit 0;
+
           else
             echo "Input ALLOW_SEVERITY_LEVEL was not one of the known values, found "$ALLOW_SEVERITY_LEVEL". If you see this message, please contact SKIP.";
             exit 1;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -238,7 +238,7 @@ jobs:
 
           elif [[ $ALLOW_SEVERITY_LEVEL == 'high' ]]
           then
-            if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
+            if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical }} == 'true' ]]
             then
               echo "Only high vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high.";
               exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -187,6 +187,7 @@ jobs:
 
   check-github-security:
     name: Check Github Security Code Scanning
+    if: ${{ success() }}
     needs: [tfsec, trivy, setup-env]
     runs-on: ubuntu-latest
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -187,7 +187,6 @@ jobs:
 
   check-github-security:
     name: Check Github Security Code Scanning
-    if: ${{ always() }}
     needs: [tfsec, trivy, setup-env]
     runs-on: ubuntu-latest
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -31,9 +31,9 @@ on:
         default: true
         type: boolean
       allow_severity_level:
-        description: 'A string which determines the level of severity the security scans can find while still succeeding workflows. Only "not_allowed", "high" and "critical" values are allowed. Note that these values are case sensitive.'
+        description: 'A string which determines the level of severity the security scans can find while still succeeding workflows. Only "none", "high" and "critical" values are allowed. Note that these values are case sensitive. Note also that a severity level of "none" still allows medium/low severities, as these are not considered dangerous.'
         required: false
-        default: not_allowed
+        default: none
         type: string
 
 env:
@@ -63,9 +63,9 @@ jobs:
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
       - name: Check severity level
-        if: inputs.allow_severity_level != 'not_allowed' && inputs.allow_severity_level != 'high' && inputs.allow_severity_level != 'critical'
+        if: inputs.allow_severity_level != 'none' && inputs.allow_severity_level != 'high' && inputs.allow_severity_level != 'critical'
         run: |
-          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'not_allowed'.";
+          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'none'. Found: "$ALLOW_SEVERITY_LEVEL".;
           exit 1;
 
   tfsec:
@@ -225,7 +225,7 @@ jobs:
             exit 0;
           fi
 
-          if [[ $ALLOW_SEVERITY_LEVEL == 'not_allowed' ]]
+          if [[ $ALLOW_SEVERITY_LEVEL == 'none' ]]
           then
             if [[ $EVENT_NAME == 'pull_request' ]]
             then

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: true
         type: boolean
+      allow_severity_level:
+        description: 'A string which determines the level of severity the security scans can find while still succeeding workflows. Only "not_allowed", "high" and "critical" values are allowed. Note that these values are case sensitive.'
+        required: false
+        default: "not_allowed"
+        type: string
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
@@ -41,6 +46,7 @@ env:
   BRANCH: ${{ github.ref_name }}
   HEAD_REF: ${{ github.head_ref }}
   EVENT_NAME: ${{ github.event_name }}
+  ALLOW_SEVERITY_LEVEL: ${{ inputs.allow_severity_levels }}
 
 jobs:
   setup-env:
@@ -56,6 +62,11 @@ jobs:
           OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
           PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
           echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+      - name: Check severity level
+        if: inputs.allow_severity_level != 'not_allowed' && inputs.allow_severity_level != 'high' && inputs.allow_severity_level != 'critical'
+        run: |
+          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'not_allowed'.";
+          exit 1;
 
   tfsec:
     name: TFSec
@@ -189,26 +200,66 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set high and critical severity outputs
+        id: severity_check_outputs
+        run: |
+          severity_check_high=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high"))] | any') 
+          severity_check_critical=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "critical"))] | any')
+          echo "severity_check_high=$severity_check_high" >> $GITHUB_OUTPUT
+          echo "severity_check_critical=$severity_check_critical" >> $GITHUB_OUTPUT
+
       # Returns 'true' if there is Code Scanning alert with 'high' or 'critical' security severity level
-      - name: Check for Critical and High Severity
+      - name: Succeed or fail based on severity
         id: severity_check
         run: |
-          severity_check=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high" or .rule.security_severity_level == "critical"))] | any') 
-          if [[ $severity_check == 'true' && $EVENT_NAME == 'pull_request' ]]
-          then
-            pr_number=$( echo $BRANCH | sed 's/\/.*//')
-            echo "Error: High or critical vulnerabilities detected on pull-request. Go to the Code Scanning section of the Github Security-tab and search for 'is:open pr:$pr_number' to review these vulnerabilities.";
-            exit 1;
-          elif [[ $severity_check == 'true' && ($BRANCH == 'main' || $BRANCH == 'master')]]
-          then
-            echo "Error: High or critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
-            exit 1;
-          elif [[ $severity_check == 'true' && $EVENT_NAME == 'workflow_dispatch' ]]
-          then
-            echo "Error: High or critical vulnerabilities detected on workflow-dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
-            exit 1;
-          else
+          pr_number=$( echo $BRANCH | sed 's/\/.*//')
+          if [[ ${{ steps.severity_check_outputs.outputs.severity_check_high == 'false' && steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
             echo "Success! No high or critical code scanning alerts."
+            exit 0;
+          fi
+
+          if [[ $ALLOW_SEVERITY_LEVEL == 'not_allowed' ]]
+          then
+            if [[ $EVENT_NAME == 'pull_request' ]]
+            then
+              echo "Error: High or critical vulnerabilities detected on pull-request. Go to the Code Scanning section of the Github Security-tab and search for 'is:open pr:$pr_number' to review these vulnerabilities.";
+              exit 1;
+            elif [[ ($BRANCH == 'main' || $BRANCH == 'master')]]
+            then
+              echo "Error: High or critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
+              exit 1;
+            elif [[ $EVENT_NAME == 'workflow_dispatch' ]]
+            then
+              echo "Error: High or critical vulnerabilities detected on workflow-dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
+              exit 1;
+            fi
+
+          elif [[ $ALLOW_SEVERITY_LEVEL == 'high' ]]
+          then
+            if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
+            then
+              echo "High vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high."
+              exit 0;
+            fi
+
+            if [[ $EVENT_NAME == 'pull_request' ]]
+            then
+              echo "Error: Critical vulnerabilities detected on pull-request. Go to the Code Scanning section of the Github Security-tab and search for 'is:open pr:$pr_number' to review these vulnerabilities.";
+              exit 1;
+            elif [[ ($BRANCH == 'main' || $BRANCH == 'master')]]
+            then
+              echo "Error: Critical vulnerabilities detected on main/master branch. Go to the Code Scanning section of the Github Security-tab to review these vulnerabilities.";
+              exit 1;
+            elif [[ $EVENT_NAME == 'workflow_dispatch' ]]
+            then
+              echo "Error: Critical vulnerabilities detected on workflow-dispatch. Go to the Code Scanning section of the Github Security-tab and review vulnerabilities related to your workflow dispatch run.";
+              exit 1;
+            fi
+
+          elif [[ $ALLOW_SEVERITY_LEVEL == 'critical' ]]
+          then
+            echo "High or critical vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to critical."
+            exit 0;
           fi
 
   attest:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -216,9 +216,9 @@ jobs:
           auth_header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
           base_url="https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{ github.ref }}&state=open"
 
-          result_severity_check_high=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=high)
-          result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=critical)
-          result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=error)
+          result_severity_check_high=$(curl -s -H "$content_header" -H "$auth_header" "${$base_url}&severity=high")
+          result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "${$base_url}&severity=critical")
+          result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${$base_url}&severity=error")
 
           is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || echo "false")
           is_critical_vuln_present=$([ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ] && echo "true" || echo "false")

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           pr_number=$( echo $BRANCH | sed 's/\/.*//');
 
-          if [[ ${{ steps.severity_check_outputs.outputs.severity_check_high == 'false' && steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
+          if [[ ${{ steps.severity_check_outputs.outputs.severity_check_high == 'false' && steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} == 'true' ]]
           then
             echo "Success! No high or critical code scanning alerts.";
             exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check severity level
         if: inputs.allow_severity_level != 'none' && inputs.allow_severity_level != 'high' && inputs.allow_severity_level != 'critical'
         run: |
-          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'none'. Found: "$ALLOW_SEVERITY_LEVEL".;
+          echo "Error: The input 'allow_severity_level' was not one of the allowed strings, 'high', 'critical' or 'none'. Found: "$ALLOW_SEVERITY_LEVEL".";
           exit 1;
 
   tfsec:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -220,8 +220,8 @@ jobs:
           result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=critical")
           result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=error")
 
-          is_high_vuln_present=$([[ "$result_severity_check_high" =~ [[a-zA-Z]] ]] && echo "true" || echo "false")
-          is_critical_vuln_present=$([[ "$result_severity_check_critical" =~ [[a-zA-Z]] || "$result_severity_check_error" =~ [[a-zA-Z]] ]] && echo "true" || echo "false")
+          is_high_vuln_present=$([[ "$result_severity_check_high" =~ [a-zA-Z] ]] && echo "true" || echo "false")
+          is_critical_vuln_present=$([[ "$result_severity_check_critical" =~ [a-zA-Z] || "$result_severity_check_error" =~ [a-zA-Z] ]] && echo "true" || echo "false")
 
           echo "is_high_vuln_present=$is_high_vuln_present" >> $GITHUB_OUTPUT
           echo "is_critical_vuln_present=$is_critical_vuln_present" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Succeed or fail based on severity
         id: severity_check
         run: |
-          pr_number=$( echo $BRANCH | sed 's/\/.*//');
+          pr_number=$( echo ${{ env.BRANCH }} | sed 's/\/.*//');
           is_high_vuln_present=${{ steps.severity_check_outputs.outputs.is_high_vuln_present }}
           is_critical_vuln_present=${{ steps.severity_check_outputs.outputs.is_critical_vuln_present }}
 
@@ -244,18 +244,18 @@ jobs:
             exit 0;
           fi
 
-          if [[ $ALLOW_SEVERITY_LEVEL == 'none' ]]
+          if [[ ${{ env.ALLOW_SEVERITY_LEVEL }} == 'none' ]]
           then
             if [[ $EVENT_NAME == 'pull_request' ]]
             then
               echo ""$error_start_message" high or critical. "$error_end_message" "$error_search_pr_message"";
               exit 1;
             else
-              echo ""$error_start_message" high or critical found on branch "$BRANCH". $error_end_message";
+              echo ""$error_start_message" high or critical found on branch "${{ env.BRANCH }}". $error_end_message";
               exit 1;
             fi
 
-          elif [[ $ALLOW_SEVERITY_LEVEL == 'high' ]]
+          elif [[ ${{ env.ALLOW_SEVERITY_LEVEL }} == 'high' ]]
           then
             if [[ $is_critical_vuln_present == 'false' ]]
             then
@@ -268,11 +268,11 @@ jobs:
               echo ""$error_start_message" critical. "$error_end_message" "$error_search_pr_message"";
               exit 1;
             else
-              echo ""$error_start_message" critical found on "$BRANCH" branch. $error_end_message";
+              echo ""$error_start_message" critical found on "${{ env.BRANCH }}" branch. $error_end_message";
               exit 1;
             fi
 
-          elif [[ $ALLOW_SEVERITY_LEVEL == 'critical' ]]
+          elif [[ ${{ env.ALLOW_SEVERITY_LEVEL }} == 'critical' ]]
           then
             echo "High or critical vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to critical.";
             exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -226,7 +226,6 @@ jobs:
           echo "is_high_vuln_present=$is_high_vuln_present" >> $GITHUB_OUTPUT
           echo "is_critical_vuln_present=$is_critical_vuln_present" >> $GITHUB_OUTPUT
 
-      # Returns 'true' if there is Code Scanning alert with 'high' or 'critical' security severity level
       - name: Succeed or fail based on severity
         id: severity_check
         run: |

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -221,7 +221,7 @@ jobs:
           result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=error")
 
           is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || echo "false")
-          is_critical_vuln_present=$([ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ] && echo "true" || echo "false")
+          is_critical_vuln_present=$([[ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ]] && echo "true" || echo "false")
 
           echo "is_high_vuln_present=$is_high_vuln_present" >> $GITHUB_OUTPUT
           echo "is_critical_vuln_present=$is_critical_vuln_present" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -220,8 +220,8 @@ jobs:
           result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=critical)
           result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=error)
 
-          is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || "false")
-          is_critical_vuln_present=$([ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ] && echo "true" || "false")
+          is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || echo "false")
+          is_critical_vuln_present=$([ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ] && echo "true" || echo "false")
 
           echo "is_high_vuln_present=$is_high_vuln_present" >> $GITHUB_OUTPUT
           echo "is_critical_vuln_present=$is_critical_vuln_present" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -220,9 +220,6 @@ jobs:
           result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=critical")
           result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "${base_url}&severity=error")
 
-          echo "$result_severity_check_critical";
-          echo "$result_severity_check_error";
-
           is_high_vuln_present=$([[ "$result_severity_check_high" =~ [[a-zA-Z]] ]] && echo "true" || echo "false")
           is_critical_vuln_present=$([[ "$result_severity_check_critical" =~ [[a-zA-Z]] || "$result_severity_check_error" =~ [[a-zA-Z]] ]] && echo "true" || echo "false")
 

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -213,9 +213,10 @@ jobs:
       - name: Succeed or fail based on severity
         id: severity_check
         run: |
-          pr_number=$( echo $BRANCH | sed 's/\/.*//')
+          pr_number=$( echo $BRANCH | sed 's/\/.*//');
+
           if [[ ${{ steps.severity_check_outputs.outputs.severity_check_high == 'false' && steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
-            echo "Success! No high or critical code scanning alerts."
+            echo "Success! No high or critical code scanning alerts.";
             exit 0;
           fi
 
@@ -239,7 +240,7 @@ jobs:
           then
             if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} ]]
             then
-              echo "High vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high."
+              echo "Only high vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high.";
               exit 0;
             fi
 
@@ -259,7 +260,7 @@ jobs:
 
           elif [[ $ALLOW_SEVERITY_LEVEL == 'critical' ]]
           then
-            echo "High or critical vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to critical."
+            echo "High or critical vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to critical.";
             exit 0;
           fi
 

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -280,6 +280,9 @@ jobs:
           then
             echo "High or critical vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to critical.";
             exit 0;
+          else
+            echo "Input ALLOW_SEVERITY_LEVEL was not one of the known values, found "$ALLOW_SEVERITY_LEVEL". If you see this message, please contact SKIP.";
+            exit 1;
           fi
 
   attest:

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -212,10 +212,19 @@ jobs:
       - name: Set high and critical severity outputs
         id: severity_check_outputs
         run: |
-          severity_check_high=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "high"))] | any') 
-          severity_check_critical=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{github.ref}} | jq '[.[] | select(.state == "open" and (.rule.security_severity_level == "critical"))] | any')
-          echo "severity_check_high=$severity_check_high" >> $GITHUB_OUTPUT
-          echo "severity_check_critical=$severity_check_critical" >> $GITHUB_OUTPUT
+          content_header="Accept: application/vnd.github+json"
+          auth_header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          base_url="https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?ref=${{ github.ref }}&state=open"
+
+          result_severity_check_high=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=high)
+          result_severity_check_critical=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=critical)
+          result_severity_check_error=$(curl -s -H "$content_header" -H "$auth_header" "$base_url"&severity=error)
+
+          is_high_vuln_present=$([ "$result_severity_check_high" != "[]" ] && echo "true" || "false")
+          is_critical_vuln_present=$([ "$result_severity_check_critical" != "[]" || "$result_severity_check_error" != "[]" ] && echo "true" || "false")
+
+          echo "is_high_vuln_present=$is_high_vuln_present" >> $GITHUB_OUTPUT
+          echo "is_critical_vuln_present=$is_critical_vuln_present" >> $GITHUB_OUTPUT
 
       # Returns 'true' if there is Code Scanning alert with 'high' or 'critical' security severity level
       - name: Succeed or fail based on severity
@@ -223,7 +232,7 @@ jobs:
         run: |
           pr_number=$( echo $BRANCH | sed 's/\/.*//');
 
-          if [[ ${{ steps.severity_check_outputs.outputs.severity_check_high == 'false' && steps.severity_check_outputs.outputs.severity_check_critical == 'false' }} == 'true' ]]
+          if [[ ${{ steps.severity_check_outputs.outputs.is_high_vuln_present == 'false' && steps.severity_check_outputs.outputs.is_critical_vuln_present == 'false' }} == 'true' ]]
           then
             echo "Success! No high or critical code scanning alerts.";
             exit 0;
@@ -247,7 +256,7 @@ jobs:
 
           elif [[ $ALLOW_SEVERITY_LEVEL == 'high' ]]
           then
-            if [[ ${{ steps.severity_check_outputs.outputs.severity_check_critical }} == 'false' ]]
+            if [[ ${{ steps.severity_check_outputs.outputs.is_critical_vuln_present }} == 'false' ]]
             then
               echo "Only high vulnerabilities detected! Allowing due to input ALLOW_SEVERITY_LEVEL being set to high.";
               exit 0;

--- a/.github/workflows/run-security-scans.yml
+++ b/.github/workflows/run-security-scans.yml
@@ -189,43 +189,6 @@ jobs:
             --keyversion="1"
           echo Attestation succeded
 
-  trivy-repo:
-    name: Trivy repo scan
-    if: inputs.trivy == true && github.event.pull_request.draft == false
-    needs: [setup-env]
-    runs-on: ubuntu-latest
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-    permissions:
-      contents: read
-      packages: write
-      # required for authentication to GCP
-      id-token: write
-      actions: read
-      security-events: write
-    env:
-      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-    steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5
-        with:
-          scan-type: fs
-          format: sarif
-          output: trivy-fs-results.sarif
-          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-          timeout: 15m
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: trivy-fs-results.sarif
-
   check-github-security:
     name: Check Github Security Code Scanning
     needs: [tfsec, trivy, setup-env]

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ jobs:
       image_url: <registry>/<repository>:<tag> or <registry>/<repository>@<digest> # the image created by build job
       trivy: <optional>
       tfsec: <optional>
+      allow_severity_level: medium
 
   dev:
     needs: [build]
@@ -245,6 +246,7 @@ jobs:
 | image_url                           | string  |          | The Docker image url must be of the form `registry/repository:tag` for run-security-scans. It is not required; however, in order to run Trivy and aquire attestations an image_url must be supplied.                                                                                                                          |
 | trivy                               | boolean |          | An optional boolean that determines whether trivy-scan will be run. Defaults to 'true'.                                                                                                                                                                                                                                       |
 | tfsec                               | boolean |          | An optional boolean that determines whether tfsec-scan will be run. Defaults to 'true'.                                                                                                                                                                                                                                       |
+| allow_severity_level                | string  |          | A string which determines the highest level of severity the security scans can find while still succeeding workflows. Only "medium", "high" and "critical" values are allowed. Note that these values are case sensitive.                                                                                                     |
 
 <br/>
 
@@ -596,11 +598,12 @@ this role.
 <br />
 
 # Troubleshooting
-See [TROUBLESHOOTING.md](TROUBLESHOOTING.md). 
-If you experience and fix an issue that isn't mentioned there, feel free to add it. 
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+If you experience and fix an issue that isn't mentioned there, feel free to add it.
 
 <br />
 
 # Contributing
 
-Get in touch with SKIP if you have any contribution suggestions, and feel free to create a pull-request. 
+Get in touch with SKIP if you have any contribution suggestions, and feel free to create a pull-request.


### PR DESCRIPTION
This PR aims to allow the users of the workflow to customize at which level of severity the security scan will allow instead of failing the workflow.

You are now able to set the `allow_severity_level` input in `run-security-scans` to one of the following: `not_allowed`, the default; `high`, allowing high vulnerabilities; `critical`, allowing critical vulnerabilities, which essentially allows all vulnerabilites.

I am not a huge fan of the branching mess this has created, but I'm not entirely sure how to clear it up right now. It has been tested extensively using shipwreck here:

https://github.com/kartverket/shipwreck/actions/workflows/build-and-rss-check.yaml