### PR TITLE
[SKIP-667] Image digest output

### DIFF
--- a/.github/workflows/post-build-attest.yml
+++ b/.github/workflows/post-build-attest.yml
@@ -22,7 +22,7 @@ on:
         type: string
     outputs:
       full_image_url:
-        description: The full image as used during attestation. Must be used during deployments of said image.
+        description: The full image path with digest as used during attestation. Must be used during deployments of said image.
         value: ${{ jobs.attest-kartverket-kontekst.outputs.full_image_url }}
 
 env:

--- a/.github/workflows/post-build-attest.yml
+++ b/.github/workflows/post-build-attest.yml
@@ -20,6 +20,10 @@ on:
         description: "Setting an image_url of the form registry/repository:tag or registry/repository@digest enables the binary attestation of that image."
         required: true
         type: string
+    outputs:
+      full_image_url:
+        description: The full image as used during attestation. Must be used during deployments of said image.
+        value: ${{ jobs.attest-kartverket-kontekst.outputs.full_image_url }}
 
 env:
   WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
@@ -49,6 +53,8 @@ jobs:
     name: Image in context of kartverket
     needs: [setup-env]
     runs-on: ubuntu-latest
+    outputs:
+      full_image_url: ${{ steps.image-digest-url.outputs.image_url }}
     defaults:
       run:
         shell: bash

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
       image_url: <registry>/<repository>:<tag> or <registry>/<repository>@<digest> # the image created by build job
 ```
 
-### Options
+### Inputs
 
 | Key                                 | Type   | Required | Description                                                                                                                                                                                                                                                                                                                   |
 | ----------------------------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,6 +76,12 @@ jobs:
 | workload_identity_provider_override | string |          | The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project_number}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`. |
 | service_account                     | string | X        | The GCP service account connected to the identity pool that will be used by Terraform. Should be the dev environment deploy service account                                                                                                                                                                                   |
 | image_url                           | string | X        | The Docker image url must be of the form `registry/repository:tag` or `registry/repository@digest`                                                                                                                                                                                                                            |
+
+### Outputs
+
+| Key            | Type   | Description                                                                                                |
+| -------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| full_image_url | string | The full image path with digest as used during attestation. Must be used during deployments of said image. |
 
 <br/>
 
@@ -145,7 +151,7 @@ jobs:
     # approximately the same as 'dev' but for the prod environment
 ```
 
-### Options
+### Inputs
 
 | Key                                 | Type    | Required | Description                                                                                                                                                                                                                                                                                                                   |
 | ----------------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -234,14 +240,14 @@ jobs:
     # call to run-terraform.yml for prod environment only after security-scans job, with build image
 ```
 
-### Options
+### Inputs
 
 | Key                                 | Type    | Required | Description                                                                                                                                                                                                                                                                                                                   |
 | ----------------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | auth_project_number                 | string  | X        | The GCP Project Number used as the active project. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool. This project should be your dev environment project, as this is the environment where the attestors are located                                                        |
 | workload_identity_provider_override | string  |          | The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project_number}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`. |
 | service_account                     | string  | X        | The GCP service account connected to the identity pool that will be used by Terraform. Should be the dev environment deploy service account                                                                                                                                                                                   |
-| image_url                           | string  |          | The Docker image url must be of the form `registry/repository:tag` for run-security-scans. It is not required; however, in order to run Trivy and aquire attestations an image_url must be supplied.                                                                                                                          |
+| image_url                           | string  |          | The Docker image url must be of the form `registry/repository:tag` or `registry/repository@digest` for run-security-scans. It is not required; however, in order to run Trivy and aquire attestations an image_url must be supplied.                                                                                          |
 | trivy                               | boolean |          | An optional boolean that determines whether trivy-scan will be run. Defaults to 'true'.                                                                                                                                                                                                                                       |
 | tfsec                               | boolean |          | An optional boolean that determines whether tfsec-scan will be run. Defaults to 'true'.                                                                                                                                                                                                                                       |
 | allow_severity_level                | string  |          | A string which determines the highest level of severity the security scans can find while still succeeding workflows. Only "medium", "high" and "critical" values are allowed. Note that these values are case sensitive.                                                                                                     |
@@ -376,7 +382,7 @@ jobs:
       tfsec: <optional>
 
   dev:
-    needs: [build]
+    needs: [post-build-attest]
     name: Deploy to dev
     permissions:
       # For logging on to Vault, GCP
@@ -393,7 +399,7 @@ jobs:
       environment: dev
       kubernetes_cluster: atkv1-dev
       terraform_workspace: dev
-      terraform_option_1: -var-file=dev.tfvars -var=image=${{ needs.build.outputs.image_tag_url}} # the image created by the build job
+      terraform_option_1: -var-file=dev.tfvars -var=image=${{ needs.post-build-attest.outputs.full_image_url }}
       terraform_init_option_1: -backend-config=dev.gcs.tfbackend
       working_directory: terraform
       auth_project_number: "123456789123"
@@ -401,7 +407,7 @@ jobs:
       project_id: project-dev-123
 
   test:
-    needs: [build, dev]
+    needs: [post-build-attest, dev]
     name: Deploy to test
     permissions:
       # For logging on to Vault, GCP
@@ -418,7 +424,7 @@ jobs:
       environment: test
       kubernetes_cluster: atkv1-test
       terraform_workspace: test
-      terraform_option_1: -var-file=test.tfvars -var=image=${{ needs.build.outputs.image_tag_url}} # the image created by the build job
+      terraform_option_1: -var-file=test.tfvars -var=image=${{ needs.post-build-attest.outputs.full_image_url }}
       terraform_init_option_1: -backend-config=test.gcs.tfbackend
       working_directory: terraform
       auth_project_number: "123456789123"
@@ -443,7 +449,7 @@ jobs:
       environment: prod
       kubernetes_cluster: atkv1-prod
       terraform_workspace: prod
-      terraform_option_1: -var-file=prod.tfvars -var=image=${{ needs.build.outputs.image_tag_url}} # the image created by the build job
+      terraform_option_1: -var-file=prod.tfvars -var=image=${{ needs.post-build-attest.outputs.full_image_url }}
       terraform_init_option_1: -backend-config=prod.gcs.tfbackend
       working_directory: terraform
       auth_project_number: "123456789123"
@@ -477,7 +483,7 @@ jobs:
 
   dev:
     name: Deploy to dev
-    needs: [build]
+    needs: [build, post-build-attest]
     permissions:
       # For logging on to Vault, GCP
       id-token: write
@@ -493,7 +499,7 @@ jobs:
       environment: dev
       kubernetes_cluster: atkv1-dev
       terraform_workspace: dev
-      terraform_option_1: -var-file=dev.tfvars -var=image=${{ needs.build.outputs.image_tag_url}} # the image created by the build job
+      terraform_option_1: -var-file=dev.tfvars -var=image=${{ needs.post-build-attest.outputs.full_image_url }}
       terraform_init_option_1: -backend-config=dev.gcs.tfbackend
       working_directory: terraform
       auth_project_number: "123456789123"


### PR DESCRIPTION
Adds the full path with image digest as an output on the `post-build-attest` workflow. This output may then be used in further deployment steps.

Tested with sha-tag: https://github.com/kartverket/shipwreck/actions/runs/4075539464/jobs/7022087591
Tested with SemVer tag: https://github.com/kartverket/shipwreck/actions/runs/4075597892/jobs/7022228607