### PR TITLE
Explicitly set location in get-credentials

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -237,7 +237,7 @@ jobs:
         if: env.KUBERNETES_CLUSTER != ''
         run: |
           gcloud components install gke-gcloud-auth-plugin
-          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug
+          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
 
       - name: Authenticate with Vault
         if: env.VAULT_ROLE != ''
@@ -495,7 +495,7 @@ jobs:
         if: env.KUBERNETES_CLUSTER != ''
         run: |
           gcloud components install gke-gcloud-auth-plugin
-          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug
+          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
 
       - name: Authenticate with Vault
         if: env.VAULT_ROLE != ''


### PR DESCRIPTION
[europe-west9 is having issues](https://status.cloud.google.com/incidents/dS9ps52MUnxQfyDGPfkY#73mBtVKKfeJGJ1yaY7hV) which causes the following issue:

```
ERROR: (gcloud.container.hub.memberships.get-credentials) Locations ['europe-west9'] are currently unreachable. Please specify memberships using `--location` or the full resource name (projects/*/locations/*/memberships/*)
```

Explicitly setting location prevents issues when a region is down.