### PR TITLE
Add dependabot auto merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -24,25 +24,27 @@ jobs:
       - name: Read configfile
         id: read-configfile
         uses: actions/github-script@v7
+        env:
+            DEPENDENCY_NAMES: ${{steps.dependabot-metadata.outputs.dependency-names}}
+            UPDATE_TYPE: ${{steps.dependabot-metadata.outputs.update-type}}
         with:
           script: |
             const fs = require('fs');
-            const dependencyNames = ${{steps.dependabot-metadata.outputs.dependency-names}};
-            const updateType = '${{steps.dependabot-metadata.outputs.update-type}}';
-            console.log({ dependencyNames })
+            const { DEPENDENCY_NAMES, UPDATE_TYPE, CONFIG_FILE } = process.env;
+            console.log({ DEPENDENCY_NAMES, UPDATE_TYPE })
             // [{ match: { dependency_name: "..", update_type: "semver:.."}}]
-            const data = fs.readFileSync(process.env.CONFIG_FILE, 'utf8');
+            const data = fs.readFileSync(CONFIG_FILE, 'utf8');
             console.log({ data })
             if (!data) return false;
             
             // Set this to true if we find a matching dependency update
             const shouldMerge = data?.some(dependency => {
-                if (!dependencyNames?.includes(dependency?.dependency_name)) return false;
+                if (!DEPENDENCY_NAMES?.includes(dependency?.dependency_name)) return false;
                 switch (dependency?.update_type) {
                   // Fallthrough until we hit a result. Major also matches minor and so on.
-                  case 'semver:major': if (updateType === 'version-update:semver-major') return true;
-                  case 'semver:minor': if (updateType === 'version-update:semver-minor') return true;
-                  case 'semver:patch': if (updateType === 'version-update:semver-patch') return true;
+                  case 'semver:major': if (UPDATE_TYPE === 'version-update:semver-major') return true;
+                  case 'semver:minor': if (UPDATE_TYPE === 'version-update:semver-minor') return true;
+                  case 'semver:patch': if (UPDATE_TYPE === 'version-update:semver-patch') return true;
                   default: return false;
                 }
             })

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,60 @@
+name: Dependabot auto-merge
+
+on:
+  workflow_call:
+    inputs: {}
+
+env:
+  CONFIG_FILE: .github/auto-merge.yml
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+            scope: kartverket/gcp-service-accounts
+            identity: auto-update
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Read configfile
+        id: read-configfile
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const dependencyNames = ${{steps.dependabot-metadata.outputs.dependency-names}};
+            const updateType = '${{steps.dependabot-metadata.outputs.update-type}}';
+            console.log({ dependencyNames })
+            // [{ match: { dependency_name: "..", update_type: "semver:.."}}]
+            const data = fs.readFileSync(process.env.CONFIG_FILE, 'utf8');
+            console.log({ data })
+            if (!data) return false;
+            
+            // Set this to true if we find a matching dependency update
+            const shouldMerge = data.?some(dependency => {
+                if (!dependencyNames.includes(dependency.dependency_name)) return false;
+                switch (dependency.update_type) {
+                  // Fallthrough until we hit a result. Major also matches minor and so on.
+                  case 'semver:major': if (updateType === 'version-update:semver-major') return true;
+                  case 'semver:minor': if (updateType === 'version-update:semver-minor') return true;
+                  case 'semver:patch': if (updateType === 'version-update:semver-patch') return true;
+                  default: return false;
+                }
+            })
+
+            console.log({ shouldMerge })
+            return shouldMerge;
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.read-configfile.outputs.result}}
+        run: |
+          gh pr review --approve -b "Dependency matches hashicorp/google-beta, merging" "$PR_URL"
+          gh pr merge --merge --admin "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -35,11 +35,18 @@ jobs:
             console.log({ dependencyNames, UPDATE_TYPE })
             // [{ match: { dependency_name: "..", update_type: "semver:.."}}]
             const data = fs.readFileSync(CONFIG_FILE, 'utf8');
-            console.log({ data })
             if (!data) return false;
+            let json;
+            try {
+              json = JSON.parse(data);
+            } catch (e) {
+              console.error('Failed to parse configfile ' + CONFIG_FILE);
+              throw e;
+            }
+            console.log({ json })
             
             // Set this to true if we find a matching dependency update
-            const shouldMerge = data?.some(dependency => {
+            const shouldMerge = json?.some(dependency => {
                 if (!dependencyNames?.includes(dependency?.dependency_name)) return false;
                 switch (dependency?.update_type) {
                   // Fallthrough until we hit a result. Major also matches minor and so on.

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -5,7 +5,7 @@ on:
     inputs: {}
 
 env:
-  CONFIG_FILE: .github/auto-merge.yml
+  CONFIG_FILE: .github/auto-merge.json
 
 jobs:
   dependabot:
@@ -31,7 +31,8 @@ jobs:
           script: |
             const fs = require('fs');
             const { DEPENDENCY_NAMES, UPDATE_TYPE, CONFIG_FILE } = process.env;
-            console.log({ DEPENDENCY_NAMES, UPDATE_TYPE })
+            const dependencyNames = DEPENDENCY_NAMES?.split();
+            console.log({ dependencyNames, UPDATE_TYPE })
             // [{ match: { dependency_name: "..", update_type: "semver:.."}}]
             const data = fs.readFileSync(CONFIG_FILE, 'utf8');
             console.log({ data })
@@ -39,7 +40,7 @@ jobs:
             
             // Set this to true if we find a matching dependency update
             const shouldMerge = data?.some(dependency => {
-                if (!DEPENDENCY_NAMES?.includes(dependency?.dependency_name)) return false;
+                if (!dependencyNames?.includes(dependency?.dependency_name)) return false;
                 switch (dependency?.update_type) {
                   // Fallthrough until we hit a result. Major also matches minor and so on.
                   case 'semver:major': if (UPDATE_TYPE === 'version-update:semver-major') return true;

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
         id: octo-sts
         with:
-            scope: kartverket/gcp-service-accounts
+            scope: ${{ github.repository }}
             identity: auto-update
       - name: Dependabot metadata
         id: dependabot-metadata
@@ -43,25 +43,24 @@ jobs:
               console.error('Failed to parse configfile ' + CONFIG_FILE);
               throw e;
             }
-            console.log({ json })
             
             // Set this to true if we find a matching dependency update
-            const shouldMerge = json?.some(dependency => {
-                if (!dependencyNames?.includes(dependency?.dependency_name)) return false;
-                switch (dependency?.update_type) {
+            const shouldMerge = !!json?.some(({ match }) => {
+                if (!dependencyNames?.includes(match?.dependency_name)) return false;
+                switch (match?.update_type) {
                   // Fallthrough until we hit a result. Major also matches minor and so on.
                   case 'semver:major': if (UPDATE_TYPE === 'version-update:semver-major') return true;
                   case 'semver:minor': if (UPDATE_TYPE === 'version-update:semver-minor') return true;
                   case 'semver:patch': if (UPDATE_TYPE === 'version-update:semver-patch') return true;
                   default: return false;
                 }
-            })
+            });
 
-            console.log({ shouldMerge })
+            console.log({ shouldMerge });
             return shouldMerge;
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.read-configfile.outputs.result}}
+        if: ${{fromJSON(steps.read-configfile.outputs.result)}}
         run: |
           gh pr review --approve -b "Dependency matches hashicorp/google-beta, merging" "$PR_URL"
           gh pr merge --merge --admin "$PR_URL"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -36,9 +36,9 @@ jobs:
             if (!data) return false;
             
             // Set this to true if we find a matching dependency update
-            const shouldMerge = data.?some(dependency => {
-                if (!dependencyNames.includes(dependency.dependency_name)) return false;
-                switch (dependency.update_type) {
+            const shouldMerge = data?.some(dependency => {
+                if (!dependencyNames?.includes(dependency?.dependency_name)) return false;
+                switch (dependency?.update_type) {
                   // Fallthrough until we hit a result. Major also matches minor and so on.
                   case 'semver:major': if (updateType === 'version-update:semver-major') return true;
                   case 'semver:minor': if (updateType === 'version-update:semver-minor') return true;

--- a/README.md
+++ b/README.md
@@ -29,6 +29,54 @@ See [Tips and Tricks](#tips-and-tricks) for supporting information regarding usa
 
 <br/>
 
+## auto-merge-dependabot
+
+Allows auto-merging dependabot PRs that match given patterns. Useful when you are drowning in PRs and have built up trust in a set of dependencies that release often and never break. It's recommended to have a sane CI setup so that anything merged to main at least passes CI tests before going into prod
+
+### Features
+
+- Allows configuring a set of dependencies in a configfile that can be merged
+- Each dependency will allow either major, minor or patch updates (only supports semver)
+- A bot approves and merges the PR
+
+### Requirements
+
+A few requirements are necessary in order to make this work in addition to the example below. 
+
+1. Legacy branch protection rules are not supported. Your repo needs to use the more modern branch rulesets
+2. The Octo STS app needs to be added to the rulesets bypass list so that it can merge the PR
+
+### Example
+
+Example usage in `.github/workflows/auto-merge.yml`:
+```yaml
+name: Dependabot auto-merge
+on: pull_request_target
+
+jobs:
+  auto-merge-dependabot:
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@add-dependabot-merge
+```
+
+Example configfile in `.github/auto-update.json`:
+```json
+[{
+  "match": {
+    "dependency_name": "hashicorp/google",
+    "update_type": "semver:minor"
+  }
+}, {
+  "match": {
+    "dependency_name": "hashicorp/google-beta",
+    "update_type": "semver:minor"
+  }
+}]
+```
+
 ## run-terraform
 
 This workflow plans and applies Terraform config to deploy to an environment.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A few requirements are necessary in order to make this work in addition to the e
 
 1. Legacy branch protection rules are not supported. Your repo needs to use the more modern branch rulesets
 2. The Octo STS app needs to be added to the rulesets bypass list so that it can merge the PR
+3. A trust file called `.github/chainguard/auto-update.sts.yaml` needs to exist to allow the workflow to get a valid GitHub token
 
 ### Example
 
@@ -59,7 +60,7 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@add-dependabot-merge
+    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@<release tag>
 ```
 
 Example configfile in `.github/auto-update.json`:
@@ -76,6 +77,24 @@ Example configfile in `.github/auto-update.json`:
   }
 }]
 ```
+
+Example STS trust file in `.github/chainguard/auto-update.sts.yaml`:
+```yaml
+issuer: https://token.actions.githubusercontent.com
+subject: repo:kartverket/gcp-service-accounts:pull_request
+
+permissions:
+  contents: write
+  pull_requests: write
+```
+
+### Inputs
+
+The configfile is currently the only input. The configfile at `.github/auto-merge.json` supports the following values:
+
+| Key | Type | Required | Description |
+| `[].match.dependency_name` | string | true | The name of the dependency as it appears on the Dependabot PR |
+| `[].match.update_type` | string | true | Which changes should be merged. Currently supports `semver:patch`, `semver:minor` and `semver:major`. The type includes all lower tiers, for example `semver:minor` includes patch changes |
 
 ## run-terraform
 


### PR DESCRIPTION
Adds new reusable workflow that allows automatically merging PRs from dependabot that matches given patterns.

Example usage in `.github/workflows/auto-merge.yml`:
```yaml
name: Dependabot auto-merge
on: pull_request_target

jobs:
  auto-merge-dependabot:
    permissions:
      id-token: write
      contents: write
      pull-requests: write
    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@add-dependabot-merge
```

Example configfile in `.github/auto-update.json`:
```json
[{
  "match": {
    "dependency_name": "hashicorp/google",
    "update_type": "semver:minor"
  }
}, {
  "match": {
    "dependency_name": "hashicorp/google-beta",
    "update_type": "semver:minor"
  }
}]
```

See working example in https://github.com/kartverket/gcp-service-accounts/pull/402.

Requires usage of newer branch rulesets (NOT older branch protection rules) so that one can exclude octo-sts from the rule and it can merge the PR.

![image](https://github.com/user-attachments/assets/92123c7f-ced5-4643-8ecd-9eade055a86d)
