### PR TITLE
Extract and output terraform outputs from run-terraform.yml

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -104,7 +104,7 @@ on:
                 type: string
         outputs:
             tf_outputs:
-                value: ${{ jobs.run_terraform.outputs.tf_outputs }}
+                value: ${{ jobs.run_terraform.outputs.tf_outputs || '{}' }}
         secrets:
             arm_client_id:
                 description: Azure Service Principal Client ID
@@ -461,7 +461,7 @@ jobs:
         runs-on: ${{ inputs.runner }}
         environment: ${{ inputs.environment }}
         outputs:
-            tf_outputs: ${{ steps.extract.outputs.tf_outputs }}
+            tf_outputs: ${{ steps.extract.outputs.tf_outputs || '{}' }}
 
         # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
         concurrency: ${{ inputs.environment }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -1,565 +1,586 @@
 name: Run Terraform
 
 on:
-  workflow_call:
-    inputs:
-      service_account:
-        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-        required: true
-        type: string
-      auth_project_number:
-        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-        required: true
-        type: string
-      runner:
-        description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
-        required: true
-        type: string
-      workload_identity_provider_override:
-        description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
-        required: false
-        type: string
-      deploy_on:
-        description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
-        required: false
-        type: string
-      working_directory:
-        description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
-        required: false
-        type: string
-        default: "."
-      project_id:
-        description: 'The GCP Project ID to use as the "active project" when running Terraform. When deploying to Kubernetes, this must match the project in which the Kubernetes cluster is registered'
-        required: false
-        type: string
-      environment:
-        description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
-        required: false
-        type: string
-      kubernetes_cluster:
-        description: "An optional kubernetes cluster to authenticate to. Note that the project_id must match where the cluster is registered"
-        required: false
-        type: string
-      terraform_workspace:
-        description: "When provided will set a workspace as the active workspace when planning and deploying"
-        required: false
-        type: string
-      terraform_option_1:
-        description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
-        required: false
-        type: string
-      terraform_option_2:
-        description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
-        required: false
-        type: string
-      terraform_option_3:
-        description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
-        required: false
-        type: string
-      terraform_init_option_1:
-        description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
-        required: false
-        type: string
-      terraform_init_option_2:
-        description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
-        required: false
-        type: string
-      terraform_init_option_3:
-        description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
-        required: false
-        type: string
-      add_comment_on_pr:
-        description: "Setting this to `false` disables the creation of comments with info of the Terraform run on Pull Requests. When `true` the `pull-request` permission is required to be set to `write`. Defaults to `true`"
-        required: false
-        type: boolean
-        default: true
-      destroy:
-        description: "An optional boolean which runs terraform destroy when set to true. Defaluts to false"
-        required: false
-        type: boolean
-        default: false
-      unlock:
-        description: "An optional string which runs terraform force-unlock on the provided `LOCK_ID`, if set."
-        required: false
-        type: string
-        default: ""
-      use_platform_modules:
-        description: "An optional boolean which enables the octo sts identity for the terraform-modules repo. Defaults to false"
-        required: false
-        type: boolean
-        default: false
-      checkout_submodules:
-        description: "An optional boolean which enables checking out submodules. Defaults to false"
-        required: false
-        type: boolean
-        default: false
-      output_file_path:
-        description: "An optional path to a file that will be uploaded as an artifact after the terraform run"
-        required: false
-        type: string
-        default: ""
-    secrets:
-      arm_client_id:
-        description: Azure Service Principal Client ID
-        required: false
-      arm_client_secret:
-        description: Azure Service Principal Client Secret
-        required: false
-      arm_tenant_id:
-        description: Azure AD Tenant ID
-        required: false
+    workflow_call:
+        inputs:
+            service_account:
+                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+                required: true
+                type: string
+            auth_project_number:
+                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+                required: true
+                type: string
+            runner:
+                description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
+                required: true
+                type: string
+            workload_identity_provider_override:
+                description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
+                required: false
+                type: string
+            deploy_on:
+                description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
+                required: false
+                type: string
+            working_directory:
+                description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
+                required: false
+                type: string
+                default: "."
+            project_id:
+                description: 'The GCP Project ID to use as the "active project" when running Terraform. When deploying to Kubernetes, this must match the project in which the Kubernetes cluster is registered'
+                required: false
+                type: string
+            environment:
+                description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
+                required: false
+                type: string
+            kubernetes_cluster:
+                description: "An optional kubernetes cluster to authenticate to. Note that the project_id must match where the cluster is registered"
+                required: false
+                type: string
+            terraform_workspace:
+                description: "When provided will set a workspace as the active workspace when planning and deploying"
+                required: false
+                type: string
+            terraform_option_1:
+                description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
+                required: false
+                type: string
+            terraform_option_2:
+                description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
+                required: false
+                type: string
+            terraform_option_3:
+                description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
+                required: false
+                type: string
+            terraform_init_option_1:
+                description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
+                required: false
+                type: string
+            terraform_init_option_2:
+                description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
+                required: false
+                type: string
+            terraform_init_option_3:
+                description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
+                required: false
+                type: string
+            add_comment_on_pr:
+                description: "Setting this to `false` disables the creation of comments with info of the Terraform run on Pull Requests. When `true` the `pull-request` permission is required to be set to `write`. Defaults to `true`"
+                required: false
+                type: boolean
+                default: true
+            destroy:
+                description: "An optional boolean which runs terraform destroy when set to true. Defaluts to false"
+                required: false
+                type: boolean
+                default: false
+            unlock:
+                description: "An optional string which runs terraform force-unlock on the provided `LOCK_ID`, if set."
+                required: false
+                type: string
+                default: ""
+            use_platform_modules:
+                description: "An optional boolean which enables the octo sts identity for the terraform-modules repo. Defaults to false"
+                required: false
+                type: boolean
+                default: false
+            checkout_submodules:
+                description: "An optional boolean which enables checking out submodules. Defaults to false"
+                required: false
+                type: boolean
+                default: false
+            output_file_path:
+                description: "An optional path to a file that will be uploaded as an artifact after the terraform run"
+                required: false
+                type: string
+                default: ""
+            extract_terraform_outputs:
+                description: "An optional, comma-separated list of Terraform outputs to extract"
+                required: false
+                type: string
+        outputs:
+            tf_outputs:
+                value: ${{ jobs.run_terraform.outputs.tf_outputs }}
+        secrets:
+            arm_client_id:
+                description: Azure Service Principal Client ID
+                required: false
+            arm_client_secret:
+                description: Azure Service Principal Client Secret
+                required: false
+            arm_tenant_id:
+                description: Azure AD Tenant ID
+                required: false
 
 env:
-  WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
-  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-  SERVICE_ACCOUNT: ${{ inputs.service_account }}
-  DEPLOY_ON: ${{ inputs.deploy_on }}
-  WORKING_DIRECTORY: ${{ inputs.working_directory }}
-  PROJECT_ID: ${{ inputs.project_id }}
-  ENVIRONMENT: ${{ inputs.environment }}
-  KUBERNETES_CLUSTER: ${{ inputs.kubernetes_cluster }}
-  TF_TMP_WORKSPACE: ${{ inputs.terraform_workspace }}
-  DESTROY: ${{ inputs.destroy }}
-  UNLOCK: ${{ inputs.unlock }}
-  TF_INIT_OPTION_1: ${{ inputs.terraform_init_option_1 }}
-  TF_INIT_OPTION_2: ${{ inputs.terraform_init_option_2 }}
-  TF_INIT_OPTION_3: ${{ inputs.terraform_init_option_3 }}
-  TF_OPTION_1: ${{ inputs.terraform_option_1 }}
-  TF_OPTION_2: ${{ inputs.terraform_option_2 }}
-  TF_OPTION_3: ${{ inputs.terraform_option_3 }}
-  REGISTRY: ghcr.io
-  ARM_CLIENT_ID: ${{ secrets.arm_client_id }}
-  ARM_CLIENT_SECRET: ${{ secrets.arm_client_secret }}
-  ARM_TENANT_ID: ${{ secrets.arm_tenant_id }}
-  NEED_TAILSCALE: false
+    WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
+    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+    SERVICE_ACCOUNT: ${{ inputs.service_account }}
+    DEPLOY_ON: ${{ inputs.deploy_on }}
+    WORKING_DIRECTORY: ${{ inputs.working_directory }}
+    PROJECT_ID: ${{ inputs.project_id }}
+    ENVIRONMENT: ${{ inputs.environment }}
+    KUBERNETES_CLUSTER: ${{ inputs.kubernetes_cluster }}
+    TF_TMP_WORKSPACE: ${{ inputs.terraform_workspace }}
+    DESTROY: ${{ inputs.destroy }}
+    UNLOCK: ${{ inputs.unlock }}
+    TF_INIT_OPTION_1: ${{ inputs.terraform_init_option_1 }}
+    TF_INIT_OPTION_2: ${{ inputs.terraform_init_option_2 }}
+    TF_INIT_OPTION_3: ${{ inputs.terraform_init_option_3 }}
+    TF_OPTION_1: ${{ inputs.terraform_option_1 }}
+    TF_OPTION_2: ${{ inputs.terraform_option_2 }}
+    TF_OPTION_3: ${{ inputs.terraform_option_3 }}
+    REGISTRY: ghcr.io
+    ARM_CLIENT_ID: ${{ secrets.arm_client_id }}
+    ARM_CLIENT_SECRET: ${{ secrets.arm_client_secret }}
+    ARM_TENANT_ID: ${{ secrets.arm_tenant_id }}
+    NEED_TAILSCALE: false
+    EXTRACT_TERRAFORM_OUTPUTS: ${{ inputs.extract_terraform_outputs }}
 
 jobs:
-  setup-env:
-    runs-on: ubuntu-latest
-    outputs:
-      workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-    steps:
-      - name: Set vars
-        id: set-output
-        run: |
-          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+    setup-env:
+        runs-on: ubuntu-latest
+        outputs:
+            workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+        steps:
+            - name: Set vars
+              id: set-output
+              run: |
+                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
 
-  terraform_plan:
-    needs: [setup-env]
-    name: Terraform Plan
-    runs-on: ${{ inputs.runner }}
+    terraform_plan:
+        needs: [setup-env]
+        name: Terraform Plan
+        runs-on: ${{ inputs.runner }}
 
-    # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
-    concurrency: ${{ inputs.environment }}
+        # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
+        concurrency: ${{ inputs.environment }}
 
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: ${{ env.WORKING_DIRECTORY }}
-    outputs:
-      plan_exitcode: ${{ steps.plan.outputs.exitcode }}
+        # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+        defaults:
+            run:
+                shell: bash
+                working-directory: ${{ env.WORKING_DIRECTORY }}
+        outputs:
+            plan_exitcode: ${{ steps.plan.outputs.exitcode }}
 
-    env:
-      # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
-      TF_IN_AUTOMATION: true
-      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.workload_identity_provider }}
-
-    steps:
-      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
-        id: octo-sts
-        if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
-        with:
-          scope: kartverket
-          identity: kartverket_repos
-
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
-          token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
-
-      - name: hack for github internal repo access
-        if: ${{ inputs.use_platform_modules == true }}
-        run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
-
-      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3.1.2
-        with:
-          terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
-
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
-          project_id: ${{ env.PROJECT_ID }}
-
-      # Install the Gcloud suite in order to install gke-gcloud-auth-plugin plugin
-      - name: Set up Cloud SDK
-        if: env.KUBERNETES_CLUSTER != ''
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Authenticate with Kubernetes
-        if: env.KUBERNETES_CLUSTER != ''
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
-          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
-
-      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-      - name: Terraform Pre-Init
-        if: env.TF_TMP_WORKSPACE != ''
-        run: |
-          terraform init -input=false \
-            ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
-            ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
-            ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
-
-      - name: Select/Create Terraform Workspace
-        if: env.TF_TMP_WORKSPACE != ''
-        run: |
-          echo "TF_WORKSPACE=$TF_TMP_WORKSPACE" >> $GITHUB_ENV
-          terraform workspace select $TF_TMP_WORKSPACE || terraform workspace new $TF_TMP_WORKSPACE
-
-      # Initialize again in case a new workspace was selected
-      - name: Terraform Init
-        id: init
-        run: |
-          terraform init -input=false \
-            ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
-            ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
-            ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
-
-      # Run terraform force-unlock if 'unlock' is set to true
-      - name: Terraform Unlock
-        if: env.UNLOCK != ''
-        id: unlock
-        run: |
-          terraform force-unlock -force $UNLOCK
-
-      - name: Terraform Validate
-        id: validate
-        run: |
-          echo 'Run validate' | tee $GITHUB_STEP_SUMMARY
-          terraform validate -no-color | tee -a output.txt
-          cat output.txt | sed '/^::/d' >> $GITHUB_STEP_SUMMARY
-
-      # Checks that all Terraform configuration files adhere to a canonical format
-      - name: Terraform Format
-        id: format
-
-        run: |
-          echo 'Run format check' | tee -a $GITHUB_STEP_SUMMARY
-          terraform fmt -check -recursive -no-color || { echo '
-          FAILURE! The above files are not properly formatted.
-          Run `terraform fmt` in $WORKING_DIRECTORY, commit the changed files and push to fix the issue' | tee -a $GITHUB_STEP_SUMMARY ; exit 1; }
-
-      - name: Check for PostgreSQL Provider
-        id: check_postgresql
-        run: |
-          PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
-          if [ -n "$PROVIDER_CHECK" ]; then
-            echo "PostgreSQL provider found."
-            echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
-          else
-            echo "PostgreSQL provider not found."
-            echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
-          fi
-
-      - name: Tailscale
-        if: env.NEED_TAILSCALE == 'true'
-        uses: tailscale/github-action@v3
-        with:
-          oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
-          tags: tag:cloudsql-user
-
-      - name: Terraform Plan
-        id: plan
-        run: |
-          # 1. Run and send stdout to build log as usual
-          if [ "$DESTROY" == "true" ] 
-          then
-            terraform plan -destroy -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
-              ${TF_OPTION_1:+"$TF_OPTION_1"} \
-              ${TF_OPTION_2:+"$TF_OPTION_2"} \
-              ${TF_OPTION_3:+"$TF_OPTION_3"} \
-              | tee output.txt
-          else
-            terraform plan -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
-              ${TF_OPTION_1:+"$TF_OPTION_1"} \
-              ${TF_OPTION_2:+"$TF_OPTION_2"} \
-              ${TF_OPTION_3:+"$TF_OPTION_3"} \
-              | tee output.txt
-          fi  
-
-          # 2. Remove some github commands and fluff
-          # This removes any line containing "Reading...", "Read complete after", and "Refreshing state...", which are terraform lines spewed out during state reading
-          STDOUT="$(grep -v -E '(.*Reading\.\.\..*)|(.*Read complete after.*)|(.*Refreshing state\.\.\..*)' output.txt)"
-          
-          # Insert cleaned output back into output.txt
-          echo "$STDOUT" > output.txt
-
-          # 3. Write to step summary
-          cat >> $GITHUB_STEP_SUMMARY <<EOF
-          \`\`\`
-          ${STDOUT}
-          \`\`\`
-          EOF
-
-          # 4. Serialize into single-line string for transfer using outputs that only support single line
-          STDOUT="${STDOUT//'%'/'%25'}"
-          STDOUT="${STDOUT//$'\n'/'%0A'}"
-          STDOUT="${STDOUT//$'\r'/'%0D'}"
-
-          # 5. Write output 
-          echo "stdout=$STDOUT" >> $GITHUB_OUTPUT
-
-      - name: Upload Plan Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: plan-${{ env.ENVIRONMENT }}.tfplan
-          path: ${{ env.WORKING_DIRECTORY }}/plan-${{ env.ENVIRONMENT }}.tfplan
-          retention-days: 5
-
-      - name: Update Pull Request
-        uses: actions/github-script@v7
-        if: (always() && inputs.add_comment_on_pr == true && github.event_name == 'pull_request')
         env:
-          # Passing via env vars to sanitize untrusted inputs
-          VALIDATE_OUTPUT: ${{ steps.validate.outputs.stdout }}
-          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
-          FORMAT_OUTCOME: ${{ steps.format.outcome}}
-          INIT_OUTCOME: ${{ steps.init.outcome }}
-          PLAN_EXITCODE: ${{ steps.plan.outputs.exitcode }}
-          PLAN_OUTCOME: ${{ steps.plan.outcome }}
-          PLAN_FILE: ${{ env.WORKING_DIRECTORY }}/output.txt
+            # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
+            TF_IN_AUTOMATION: true
+            WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.workload_identity_provider }}
 
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID;
-            const run_link = '<a href="' + run_url + '">Actions</a>.'
-            const fs = require('fs')
-            const plan_file = fs.readFileSync(process.env.PLAN_FILE, 'utf8')
-            const plan = plan_file.length > 65000 ? plan_file.toString().substring(0, 65000) + '...' : plan_file
-            const truncated_message = plan_file.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
+        steps:
+            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+              id: octo-sts
+              if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
+              with:
+                  scope: kartverket
+                  identity: kartverket_repos
 
-            const {
-              ENVIRONMENT,
-              PLAN_EXITCODE,
-              DEPLOY_ON,
-              VALIDATE_OUTPUT,
-              FORMAT_OUTCOME,
-              INIT_OUTCOME,
-              VALIDATE_OUTCOME,
-              PLAN_OUTCOME,
-              WORKING_DIRECTORY,
-            } = process.env;
+            # Checkout the repository to the GitHub Actions runner
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
+                  token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
 
-            /* Body is in the format of
-            * <!-- @run-terraform -->
-            * <!-- @run-terraform:start:jobid -->
-            * Output of job with id jobid
-            * <!-- @run-terraform:end:jobid -->
-            */
-            const bodyStartMarker = '<!-- @run-terraform -->';
-            const comment = comments.find(({ body }) => body.startsWith(bodyStartMarker));
-            const id = comment?.id;
-            let commentBody = comment?.body ?? bodyStartMarker;
-            const bodyHasJobInfo = commentBody.includes(`<!-- @run-terraform:start:${ENVIRONMENT} -->`);
+            - name: hack for github internal repo access
+              if: ${{ inputs.use_platform_modules == true }}
+              run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
 
-            const exitcode = PLAN_EXITCODE;
-            const action = {
-              0: 'No changes detected. Will not run Terraform apply job',
-              1: 'An error occured! Will not run Terraform apply job',
-              2: `Changes detected. Will run Terraform apply job on merge to ${DEPLOY_ON}`
-            }[exitcode] ?? 'Terraform gave an unknown exit code, I don\'t know what happens next!';
+            # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v3.1.2
+              with:
+                  terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
 
-            const jobBody = `<!-- @run-terraform:start:${ENVIRONMENT} -->
-            ## Results for ${ENVIRONMENT} ${exitcode === '2' ? '– ❗ `CHANGED` ❗' : ''}
-            #### Terraform Format and Style 🖌 \`${FORMAT_OUTCOME}\`
-            #### Terraform Initialization ⚙️ \`${INIT_OUTCOME}\`
-            #### Terraform Validation 🤖 \`${VALIDATE_OUTCOME}\`
-            <details><summary>Validation Output</summary>
+            - name: Authenticate with Google Cloud
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ env.SERVICE_ACCOUNT }}
+                  project_id: ${{ env.PROJECT_ID }}
 
-            \`\`\`\n
-            ${VALIDATE_OUTPUT}
-            \`\`\`
+            # Install the Gcloud suite in order to install gke-gcloud-auth-plugin plugin
+            - name: Set up Cloud SDK
+              if: env.KUBERNETES_CLUSTER != ''
+              uses: google-github-actions/setup-gcloud@v2
 
-            </details>
+            - name: Authenticate with Kubernetes
+              if: env.KUBERNETES_CLUSTER != ''
+              run: |
+                  gcloud components install gke-gcloud-auth-plugin
+                  gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
 
-            #### Terraform Plan 📖 \`${PLAN_OUTCOME}\`
+            # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+            - name: Terraform Pre-Init
+              if: env.TF_TMP_WORKSPACE != ''
+              run: |
+                  terraform init -input=false \
+                    ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
+                    ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
+                    ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
 
-            <details><summary>Show Plan</summary>
+            - name: Select/Create Terraform Workspace
+              if: env.TF_TMP_WORKSPACE != ''
+              run: |
+                  echo "TF_WORKSPACE=$TF_TMP_WORKSPACE" >> $GITHUB_ENV
+                  terraform workspace select $TF_TMP_WORKSPACE || terraform workspace new $TF_TMP_WORKSPACE
 
-            \`\`\`\n
-            ${plan}
-            \`\`\`
+            # Initialize again in case a new workspace was selected
+            - name: Terraform Init
+              id: init
+              run: |
+                  terraform init -input=false \
+                    ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
+                    ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
+                    ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
 
-            </details>
-            ${truncated_message}
+            # Run terraform force-unlock if 'unlock' is set to true
+            - name: Terraform Unlock
+              if: env.UNLOCK != ''
+              id: unlock
+              run: |
+                  terraform force-unlock -force $UNLOCK
 
-            #### Next action 🚀
-            ${action}
+            - name: Terraform Validate
+              id: validate
+              run: |
+                  echo 'Run validate' | tee $GITHUB_STEP_SUMMARY
+                  terraform validate -no-color | tee -a output.txt
+                  cat output.txt | sed '/^::/d' >> $GITHUB_STEP_SUMMARY
 
-            *Pusher: @${{ github.actor }}, Working Directory: \`${WORKING_DIRECTORY}\`, Commit: ${{ github.sha }}, Generated at: \`${new Date().toLocaleString('nb')}\`*
-            <!-- @run-terraform:end:${ENVIRONMENT} -->`;
+            # Checks that all Terraform configuration files adhere to a canonical format
+            - name: Terraform Format
+              id: format
 
-            if (bodyHasJobInfo) {
-              commentBody = commentBody.replace(
-                new RegExp(`<!-- @run-terraform:start:${ENVIRONMENT} -->.*<!-- @run-terraform:end:${ENVIRONMENT} -->`, 's'),
-                jobBody,
-              );
-            } else {
-              commentBody += '\n' + jobBody;
-            }
+              run: |
+                  echo 'Run format check' | tee -a $GITHUB_STEP_SUMMARY
+                  terraform fmt -check -recursive -no-color || { echo '
+                  FAILURE! The above files are not properly formatted.
+                  Run `terraform fmt` in $WORKING_DIRECTORY, commit the changed files and push to fix the issue' | tee -a $GITHUB_STEP_SUMMARY ; exit 1; }
 
-            commentBody = commentBody
-              .replaceAll("%0A", "\n")
-              .replaceAll("%0D", "\n");
+            - name: Check for PostgreSQL Provider
+              id: check_postgresql
+              run: |
+                  PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
+                  if [ -n "$PROVIDER_CHECK" ]; then
+                    echo "PostgreSQL provider found."
+                    echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
+                  else
+                    echo "PostgreSQL provider not found."
+                    echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
+                  fi
 
-            if (id) {
-              github.rest.issues.updateComment({
-                comment_id: id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody
-              })
-            } else {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody
-              })
-            }
+            - name: Tailscale
+              if: env.NEED_TAILSCALE == 'true'
+              uses: tailscale/github-action@v3
+              with:
+                  oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
+                  oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
+                  tags: tag:cloudsql-user
 
-  run_terraform:
-    needs: [setup-env, terraform_plan]
-    if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
-    name: Terraform Apply or Destroy
-    runs-on: ${{ inputs.runner }}
-    environment: ${{ inputs.environment }}
+            - name: Terraform Plan
+              id: plan
+              run: |
+                  # 1. Run and send stdout to build log as usual
+                  if [ "$DESTROY" == "true" ] 
+                  then
+                    terraform plan -destroy -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
+                      ${TF_OPTION_1:+"$TF_OPTION_1"} \
+                      ${TF_OPTION_2:+"$TF_OPTION_2"} \
+                      ${TF_OPTION_3:+"$TF_OPTION_3"} \
+                      | tee output.txt
+                  else
+                    terraform plan -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
+                      ${TF_OPTION_1:+"$TF_OPTION_1"} \
+                      ${TF_OPTION_2:+"$TF_OPTION_2"} \
+                      ${TF_OPTION_3:+"$TF_OPTION_3"} \
+                      | tee output.txt
+                  fi  
 
-    # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
-    concurrency: ${{ inputs.environment }}
+                  # 2. Remove some github commands and fluff
+                  # This removes any line containing "Reading...", "Read complete after", and "Refreshing state...", which are terraform lines spewed out during state reading
+                  STDOUT="$(grep -v -E '(.*Reading\.\.\..*)|(.*Read complete after.*)|(.*Refreshing state\.\.\..*)' output.txt)"
 
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: ${{ env.WORKING_DIRECTORY }}
+                  # Insert cleaned output back into output.txt
+                  echo "$STDOUT" > output.txt
 
-    env:
-      # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
-      TF_IN_AUTOMATION: true
-      TF_WORKSPACE: ${{ inputs.terraform_workspace }}
-      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+                  # 3. Write to step summary
+                  cat >> $GITHUB_STEP_SUMMARY <<EOF
+                  \`\`\`
+                  ${STDOUT}
+                  \`\`\`
+                  EOF
 
-    steps:
-      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
-        id: octo-sts
-        if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
-        with:
-          scope: kartverket
-          identity: kartverket_repos
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
-          token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
+                  # 4. Serialize into single-line string for transfer using outputs that only support single line
+                  STDOUT="${STDOUT//'%'/'%25'}"
+                  STDOUT="${STDOUT//$'\n'/'%0A'}"
+                  STDOUT="${STDOUT//$'\r'/'%0D'}"
 
-      - name: hack for github internal repo access
-        if: ${{ inputs.use_platform_modules == true }}
-        run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
+                  # 5. Write output 
+                  echo "stdout=$STDOUT" >> $GITHUB_OUTPUT
 
-      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3.1.2
-        with:
-          terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
+            - name: Upload Plan Artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: plan-${{ env.ENVIRONMENT }}.tfplan
+                  path: ${{ env.WORKING_DIRECTORY }}/plan-${{ env.ENVIRONMENT }}.tfplan
+                  retention-days: 5
 
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
-          project_id: ${{ env.PROJECT_ID }}
+            - name: Update Pull Request
+              uses: actions/github-script@v7
+              if: (always() && inputs.add_comment_on_pr == true && github.event_name == 'pull_request')
+              env:
+                  # Passing via env vars to sanitize untrusted inputs
+                  VALIDATE_OUTPUT: ${{ steps.validate.outputs.stdout }}
+                  VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+                  FORMAT_OUTCOME: ${{ steps.format.outcome}}
+                  INIT_OUTCOME: ${{ steps.init.outcome }}
+                  PLAN_EXITCODE: ${{ steps.plan.outputs.exitcode }}
+                  PLAN_OUTCOME: ${{ steps.plan.outcome }}
+                  PLAN_FILE: ${{ env.WORKING_DIRECTORY }}/output.txt
 
-      - name: Set up Cloud SDK
-        if: env.KUBERNETES_CLUSTER != ''
-        uses: google-github-actions/setup-gcloud@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID;
+                      const run_link = '<a href="' + run_url + '">Actions</a>.'
+                      const fs = require('fs')
+                      const plan_file = fs.readFileSync(process.env.PLAN_FILE, 'utf8')
+                      const plan = plan_file.length > 65000 ? plan_file.toString().substring(0, 65000) + '...' : plan_file
+                      const truncated_message = plan_file.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
+                      const { data: comments } = await github.rest.issues.listComments({
+                        issue_number: context.issue.number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo
+                      });
 
-      - name: Authenticate with Kubernetes
-        if: env.KUBERNETES_CLUSTER != ''
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
-          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
+                      const {
+                        ENVIRONMENT,
+                        PLAN_EXITCODE,
+                        DEPLOY_ON,
+                        VALIDATE_OUTPUT,
+                        FORMAT_OUTCOME,
+                        INIT_OUTCOME,
+                        VALIDATE_OUTCOME,
+                        PLAN_OUTCOME,
+                        WORKING_DIRECTORY,
+                      } = process.env;
 
-      - name: Download Plan Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: plan-${{ env.ENVIRONMENT }}.tfplan
-          path: ${{ env.WORKING_DIRECTORY }}
+                      /* Body is in the format of
+                      * <!-- @run-terraform -->
+                      * <!-- @run-terraform:start:jobid -->
+                      * Output of job with id jobid
+                      * <!-- @run-terraform:end:jobid -->
+                      */
+                      const bodyStartMarker = '<!-- @run-terraform -->';
+                      const comment = comments.find(({ body }) => body.startsWith(bodyStartMarker));
+                      const id = comment?.id;
+                      let commentBody = comment?.body ?? bodyStartMarker;
+                      const bodyHasJobInfo = commentBody.includes(`<!-- @run-terraform:start:${ENVIRONMENT} -->`);
 
-      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-      - name: Terraform Init
-        run: |
-          terraform init -input=false \
-            ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
-            ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
-            ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
+                      const exitcode = PLAN_EXITCODE;
+                      const action = {
+                        0: 'No changes detected. Will not run Terraform apply job',
+                        1: 'An error occured! Will not run Terraform apply job',
+                        2: `Changes detected. Will run Terraform apply job on merge to ${DEPLOY_ON}`
+                      }[exitcode] ?? 'Terraform gave an unknown exit code, I don\'t know what happens next!';
 
-      - name: Check for PostgreSQL Provider
-        id: check_postgresql
-        run: |
-          PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
-          if [ -n "$PROVIDER_CHECK" ]; then
-            echo "PostgreSQL provider found."
-            echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
-          else
-            echo "PostgreSQL provider not found."
-            echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
-          fi
+                      const jobBody = `<!-- @run-terraform:start:${ENVIRONMENT} -->
+                      ## Results for ${ENVIRONMENT} ${exitcode === '2' ? '– ❗ `CHANGED` ❗' : ''}
+                      #### Terraform Format and Style 🖌 \`${FORMAT_OUTCOME}\`
+                      #### Terraform Initialization ⚙️ \`${INIT_OUTCOME}\`
+                      #### Terraform Validation 🤖 \`${VALIDATE_OUTCOME}\`
+                      <details><summary>Validation Output</summary>
 
-      - name: Tailscale
-        if: env.NEED_TAILSCALE == 'true'
-        uses: tailscale/github-action@v3
-        with:
-          oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
-          tags: tag:cloudsql-user
+                      \`\`\`\n
+                      ${VALIDATE_OUTPUT}
+                      \`\`\`
 
-      # Run terraform destroy on push to main if 'destroy' is set to true
-      - name: Terraform Destroy
-        if: env.DESTROY == 'true'
-        id: destroy
-        run: |
-          terraform destroy -auto-approve \
-            ${TF_OPTION_1:+"$TF_OPTION_1"} \
-            ${TF_OPTION_2:+"$TF_OPTION_2"} \
-            ${TF_OPTION_3:+"$TF_OPTION_3"}
+                      </details>
 
-      - name: Run Terraform
-        if: env.DESTROY == 'false'
-        run: terraform apply -input=false plan-$ENVIRONMENT.tfplan
+                      #### Terraform Plan 📖 \`${PLAN_OUTCOME}\`
 
-      - name: Upload output artifact
-        if: ${{ inputs.output_file_path != '' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: output-file
-          path: ${{ inputs.output_file_path }}
+                      <details><summary>Show Plan</summary>
+
+                      \`\`\`\n
+                      ${plan}
+                      \`\`\`
+
+                      </details>
+                      ${truncated_message}
+
+                      #### Next action 🚀
+                      ${action}
+
+                      *Pusher: @${{ github.actor }}, Working Directory: \`${WORKING_DIRECTORY}\`, Commit: ${{ github.sha }}, Generated at: \`${new Date().toLocaleString('nb')}\`*
+                      <!-- @run-terraform:end:${ENVIRONMENT} -->`;
+
+                      if (bodyHasJobInfo) {
+                        commentBody = commentBody.replace(
+                          new RegExp(`<!-- @run-terraform:start:${ENVIRONMENT} -->.*<!-- @run-terraform:end:${ENVIRONMENT} -->`, 's'),
+                          jobBody,
+                        );
+                      } else {
+                        commentBody += '\n' + jobBody;
+                      }
+
+                      commentBody = commentBody
+                        .replaceAll("%0A", "\n")
+                        .replaceAll("%0D", "\n");
+
+                      if (id) {
+                        github.rest.issues.updateComment({
+                          comment_id: id,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: commentBody
+                        })
+                      } else {
+                        github.rest.issues.createComment({
+                          issue_number: context.issue.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: commentBody
+                        })
+                      }
+
+    run_terraform:
+        needs: [setup-env, terraform_plan]
+        if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+        name: Terraform Apply or Destroy
+        runs-on: ${{ inputs.runner }}
+        environment: ${{ inputs.environment }}
+        outputs:
+            tf_outputs: ${{ steps.extract.outputs.tf_outputs }}
+
+        # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
+        concurrency: ${{ inputs.environment }}
+
+        # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+        defaults:
+            run:
+                shell: bash
+                working-directory: ${{ env.WORKING_DIRECTORY }}
+
+        env:
+            # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
+            TF_IN_AUTOMATION: true
+            TF_WORKSPACE: ${{ inputs.terraform_workspace }}
+            WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+
+        steps:
+            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+              id: octo-sts
+              if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
+              with:
+                  scope: kartverket
+                  identity: kartverket_repos
+            # Checkout the repository to the GitHub Actions runner
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
+                  token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
+
+            - name: hack for github internal repo access
+              if: ${{ inputs.use_platform_modules == true }}
+              run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
+
+            # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v3.1.2
+              with:
+                  terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
+
+            - name: Authenticate with Google Cloud
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ env.SERVICE_ACCOUNT }}
+                  project_id: ${{ env.PROJECT_ID }}
+
+            - name: Set up Cloud SDK
+              if: env.KUBERNETES_CLUSTER != ''
+              uses: google-github-actions/setup-gcloud@v2
+
+            - name: Authenticate with Kubernetes
+              if: env.KUBERNETES_CLUSTER != ''
+              run: |
+                  gcloud components install gke-gcloud-auth-plugin
+                  gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
+
+            - name: Download Plan Artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: plan-${{ env.ENVIRONMENT }}.tfplan
+                  path: ${{ env.WORKING_DIRECTORY }}
+
+            # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+            - name: Terraform Init
+              run: |
+                  terraform init -input=false \
+                    ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
+                    ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
+                    ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
+
+            - name: Check for PostgreSQL Provider
+              id: check_postgresql
+              run: |
+                  PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
+                  if [ -n "$PROVIDER_CHECK" ]; then
+                    echo "PostgreSQL provider found."
+                    echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
+                  else
+                    echo "PostgreSQL provider not found."
+                    echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
+                  fi
+
+            - name: Tailscale
+              if: env.NEED_TAILSCALE == 'true'
+              uses: tailscale/github-action@v3
+              with:
+                  oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
+                  oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
+                  tags: tag:cloudsql-user
+
+            # Run terraform destroy on push to main if 'destroy' is set to true
+            - name: Terraform Destroy
+              if: env.DESTROY == 'true'
+              id: destroy
+              run: |
+                  terraform destroy -auto-approve \
+                    ${TF_OPTION_1:+"$TF_OPTION_1"} \
+                    ${TF_OPTION_2:+"$TF_OPTION_2"} \
+                    ${TF_OPTION_3:+"$TF_OPTION_3"}
+
+            - name: Run Terraform
+              if: env.DESTROY == 'false'
+              run: terraform apply -input=false plan-$ENVIRONMENT.tfplan
+
+            - name: Extract Terraform Outputs
+              if: env.EXTRACT_TERRAFORM_OUTPUTS != ''
+              id: extract
+              run: |
+                  OUTPUTS=$(terraform output -json)
+                  REQUESTED_OUTPUTS="${{ env.EXTRACT_TERRAFORM_OUTPUTS }}"
+                  JQ_KEYS=$(echo "$REQUESTED" | awk -F',' '{for(i=1;i<=NF;i++) printf "\"%s\": .%s,", $i, $i}' | sed 's/,$//')
+
+                  FILTERED=$(echo "$OUTPUTS" | jq "{ $JQ_KEYS }")
+                  echo "tf_outputs=$FILTERED" >> $GITHUB_OUTPUT
+
+            - name: Upload output artifact
+              if: ${{ inputs.output_file_path != '' }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: output-file
+                  path: ${{ inputs.output_file_path }}

--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -1,586 +1,586 @@
 name: Run Terraform
 
 on:
-    workflow_call:
-        inputs:
-            service_account:
-                description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
-                required: true
-                type: string
-            auth_project_number:
-                description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
-                required: true
-                type: string
-            runner:
-                description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
-                required: true
-                type: string
-            workload_identity_provider_override:
-                description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
-                required: false
-                type: string
-            deploy_on:
-                description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
-                required: false
-                type: string
-            working_directory:
-                description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
-                required: false
-                type: string
-                default: "."
-            project_id:
-                description: 'The GCP Project ID to use as the "active project" when running Terraform. When deploying to Kubernetes, this must match the project in which the Kubernetes cluster is registered'
-                required: false
-                type: string
-            environment:
-                description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
-                required: false
-                type: string
-            kubernetes_cluster:
-                description: "An optional kubernetes cluster to authenticate to. Note that the project_id must match where the cluster is registered"
-                required: false
-                type: string
-            terraform_workspace:
-                description: "When provided will set a workspace as the active workspace when planning and deploying"
-                required: false
-                type: string
-            terraform_option_1:
-                description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
-                required: false
-                type: string
-            terraform_option_2:
-                description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
-                required: false
-                type: string
-            terraform_option_3:
-                description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
-                required: false
-                type: string
-            terraform_init_option_1:
-                description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
-                required: false
-                type: string
-            terraform_init_option_2:
-                description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
-                required: false
-                type: string
-            terraform_init_option_3:
-                description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
-                required: false
-                type: string
-            add_comment_on_pr:
-                description: "Setting this to `false` disables the creation of comments with info of the Terraform run on Pull Requests. When `true` the `pull-request` permission is required to be set to `write`. Defaults to `true`"
-                required: false
-                type: boolean
-                default: true
-            destroy:
-                description: "An optional boolean which runs terraform destroy when set to true. Defaluts to false"
-                required: false
-                type: boolean
-                default: false
-            unlock:
-                description: "An optional string which runs terraform force-unlock on the provided `LOCK_ID`, if set."
-                required: false
-                type: string
-                default: ""
-            use_platform_modules:
-                description: "An optional boolean which enables the octo sts identity for the terraform-modules repo. Defaults to false"
-                required: false
-                type: boolean
-                default: false
-            checkout_submodules:
-                description: "An optional boolean which enables checking out submodules. Defaults to false"
-                required: false
-                type: boolean
-                default: false
-            output_file_path:
-                description: "An optional path to a file that will be uploaded as an artifact after the terraform run"
-                required: false
-                type: string
-                default: ""
-            extract_terraform_outputs:
-                description: "An optional, comma-separated list of Terraform outputs to extract"
-                required: false
-                type: string
-        outputs:
-            tf_outputs:
-                value: ${{ jobs.run_terraform.outputs.tf_outputs || '{}' }}
-        secrets:
-            arm_client_id:
-                description: Azure Service Principal Client ID
-                required: false
-            arm_client_secret:
-                description: Azure Service Principal Client Secret
-                required: false
-            arm_tenant_id:
-                description: Azure AD Tenant ID
-                required: false
+  workflow_call:
+    inputs:
+      service_account:
+        description: "The GCP service account connected to the identity pool that will be used by Terraform for authentication to GCP."
+        required: true
+        type: string
+      auth_project_number:
+        description: "The GCP Project Number used for authentication. A 12-digit number used as a unique identifier for the project. Used to find workload identity pool."
+        required: true
+        type: string
+      runner:
+        description: "The GitHub runner to use when running the deploy. This can for example be `atkv1-dev`"
+        required: true
+        type: string
+      workload_identity_provider_override:
+        description: "The ID of the provider to use for authentication. Only used for overriding the default workload identity provider based on project number. It should be in the format of `projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/providers/{{workload_identity_pool_provider_id}}`"
+        required: false
+        type: string
+      deploy_on:
+        description: "Which branch will be the only branch allowed to deploy. This defaults to the main branch so that other branches only run check and plan. Defaults to `refs/heads/main`"
+        required: false
+        type: string
+      working_directory:
+        description: "The directory in which to run terraform, i.e. where the Terraform files are placed. The path is relative to the root of the repository"
+        required: false
+        type: string
+        default: "."
+      project_id:
+        description: 'The GCP Project ID to use as the "active project" when running Terraform. When deploying to Kubernetes, this must match the project in which the Kubernetes cluster is registered'
+        required: false
+        type: string
+      environment:
+        description: "The GitHub environment to use when deploying. See [using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) for more info on this"
+        required: false
+        type: string
+      kubernetes_cluster:
+        description: "An optional kubernetes cluster to authenticate to. Note that the project_id must match where the cluster is registered"
+        required: false
+        type: string
+      terraform_workspace:
+        description: "When provided will set a workspace as the active workspace when planning and deploying"
+        required: false
+        type: string
+      terraform_option_1:
+        description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
+        required: false
+        type: string
+      terraform_option_2:
+        description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
+        required: false
+        type: string
+      terraform_option_3:
+        description: "An additional terraform option to be passed to plan and apply. For example `-var-file=dev.tfvars` and `-var=<variableName>=<variableValue>`"
+        required: false
+        type: string
+      terraform_init_option_1:
+        description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
+        required: false
+        type: string
+      terraform_init_option_2:
+        description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
+        required: false
+        type: string
+      terraform_init_option_3:
+        description: "An additional config to be passed to terraform init. For example `-backend-config=dev.gcs.tfbackend`"
+        required: false
+        type: string
+      add_comment_on_pr:
+        description: "Setting this to `false` disables the creation of comments with info of the Terraform run on Pull Requests. When `true` the `pull-request` permission is required to be set to `write`. Defaults to `true`"
+        required: false
+        type: boolean
+        default: true
+      destroy:
+        description: "An optional boolean which runs terraform destroy when set to true. Defaluts to false"
+        required: false
+        type: boolean
+        default: false
+      unlock:
+        description: "An optional string which runs terraform force-unlock on the provided `LOCK_ID`, if set."
+        required: false
+        type: string
+        default: ""
+      use_platform_modules:
+        description: "An optional boolean which enables the octo sts identity for the terraform-modules repo. Defaults to false"
+        required: false
+        type: boolean
+        default: false
+      checkout_submodules:
+        description: "An optional boolean which enables checking out submodules. Defaults to false"
+        required: false
+        type: boolean
+        default: false
+      output_file_path:
+        description: "An optional path to a file that will be uploaded as an artifact after the terraform run"
+        required: false
+        type: string
+        default: ""
+      extract_terraform_outputs:
+        description: "An optional, comma-separated list of Terraform outputs to extract"
+        required: false
+        type: string
+    outputs:
+      tf_outputs:
+        value: ${{ jobs.run_terraform.outputs.tf_outputs || '{}' }}
+    secrets:
+      arm_client_id:
+        description: Azure Service Principal Client ID
+        required: false
+      arm_client_secret:
+        description: Azure Service Principal Client Secret
+        required: false
+      arm_tenant_id:
+        description: Azure AD Tenant ID
+        required: false
 
 env:
-    WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
-    AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
-    SERVICE_ACCOUNT: ${{ inputs.service_account }}
-    DEPLOY_ON: ${{ inputs.deploy_on }}
-    WORKING_DIRECTORY: ${{ inputs.working_directory }}
-    PROJECT_ID: ${{ inputs.project_id }}
-    ENVIRONMENT: ${{ inputs.environment }}
-    KUBERNETES_CLUSTER: ${{ inputs.kubernetes_cluster }}
-    TF_TMP_WORKSPACE: ${{ inputs.terraform_workspace }}
-    DESTROY: ${{ inputs.destroy }}
-    UNLOCK: ${{ inputs.unlock }}
-    TF_INIT_OPTION_1: ${{ inputs.terraform_init_option_1 }}
-    TF_INIT_OPTION_2: ${{ inputs.terraform_init_option_2 }}
-    TF_INIT_OPTION_3: ${{ inputs.terraform_init_option_3 }}
-    TF_OPTION_1: ${{ inputs.terraform_option_1 }}
-    TF_OPTION_2: ${{ inputs.terraform_option_2 }}
-    TF_OPTION_3: ${{ inputs.terraform_option_3 }}
-    REGISTRY: ghcr.io
-    ARM_CLIENT_ID: ${{ secrets.arm_client_id }}
-    ARM_CLIENT_SECRET: ${{ secrets.arm_client_secret }}
-    ARM_TENANT_ID: ${{ secrets.arm_tenant_id }}
-    NEED_TAILSCALE: false
-    EXTRACT_TERRAFORM_OUTPUTS: ${{ inputs.extract_terraform_outputs }}
+  WORKLOAD_IDENTITY_PROVIDER_OVERRIDE: ${{ inputs.workload_identity_provider_override }}
+  AUTH_PROJECT_NUMBER: ${{ inputs.auth_project_number }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account }}
+  DEPLOY_ON: ${{ inputs.deploy_on }}
+  WORKING_DIRECTORY: ${{ inputs.working_directory }}
+  PROJECT_ID: ${{ inputs.project_id }}
+  ENVIRONMENT: ${{ inputs.environment }}
+  KUBERNETES_CLUSTER: ${{ inputs.kubernetes_cluster }}
+  TF_TMP_WORKSPACE: ${{ inputs.terraform_workspace }}
+  DESTROY: ${{ inputs.destroy }}
+  UNLOCK: ${{ inputs.unlock }}
+  TF_INIT_OPTION_1: ${{ inputs.terraform_init_option_1 }}
+  TF_INIT_OPTION_2: ${{ inputs.terraform_init_option_2 }}
+  TF_INIT_OPTION_3: ${{ inputs.terraform_init_option_3 }}
+  TF_OPTION_1: ${{ inputs.terraform_option_1 }}
+  TF_OPTION_2: ${{ inputs.terraform_option_2 }}
+  TF_OPTION_3: ${{ inputs.terraform_option_3 }}
+  REGISTRY: ghcr.io
+  ARM_CLIENT_ID: ${{ secrets.arm_client_id }}
+  ARM_CLIENT_SECRET: ${{ secrets.arm_client_secret }}
+  ARM_TENANT_ID: ${{ secrets.arm_tenant_id }}
+  NEED_TAILSCALE: false
+  EXTRACT_TERRAFORM_OUTPUTS: ${{ inputs.extract_terraform_outputs }}
 
 jobs:
-    setup-env:
-        runs-on: ubuntu-latest
-        outputs:
-            workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-        steps:
-            - name: Set vars
-              id: set-output
-              run: |
-                  PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
-                  DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
-                  OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
-                  PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
-                  echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
+  setup-env:
+    runs-on: ubuntu-latest
+    outputs:
+      workload_identity_provider: ${{ steps.set-output.outputs.WORKLOAD_IDENTITY_PROVIDER }}
+    steps:
+      - name: Set vars
+        id: set-output
+        run: |
+          PRODUCT_NAME=$(echo $SERVICE_ACCOUNT | sed 's/-deploy.*//')
+          DEFAULT_WORKLOAD_IDENTITY="projects/$AUTH_PROJECT_NUMBER/locations/global/workloadIdentityPools/$PRODUCT_NAME-deploy-pool/providers/github-provider"
+          OVERRIDE=$WORKLOAD_IDENTITY_PROVIDER_OVERRIDE
+          PROVIDER=${OVERRIDE:-$DEFAULT_WORKLOAD_IDENTITY}
+          echo "WORKLOAD_IDENTITY_PROVIDER=$PROVIDER" >> $GITHUB_OUTPUT
 
-    terraform_plan:
-        needs: [setup-env]
-        name: Terraform Plan
-        runs-on: ${{ inputs.runner }}
+  terraform_plan:
+    needs: [setup-env]
+    name: Terraform Plan
+    runs-on: ${{ inputs.runner }}
 
-        # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
-        concurrency: ${{ inputs.environment }}
+    # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
+    concurrency: ${{ inputs.environment }}
 
-        # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-        defaults:
-            run:
-                shell: bash
-                working-directory: ${{ env.WORKING_DIRECTORY }}
-        outputs:
-            plan_exitcode: ${{ steps.plan.outputs.exitcode }}
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+    outputs:
+      plan_exitcode: ${{ steps.plan.outputs.exitcode }}
 
+    env:
+      # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
+      TF_IN_AUTOMATION: true
+      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.workload_identity_provider }}
+
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
+        with:
+          scope: kartverket
+          identity: kartverket_repos
+
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
+          token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
+
+      - name: hack for github internal repo access
+        if: ${{ inputs.use_platform_modules == true }}
+        run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
+
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+        with:
+          terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          project_id: ${{ env.PROJECT_ID }}
+
+      # Install the Gcloud suite in order to install gke-gcloud-auth-plugin plugin
+      - name: Set up Cloud SDK
+        if: env.KUBERNETES_CLUSTER != ''
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Authenticate with Kubernetes
+        if: env.KUBERNETES_CLUSTER != ''
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
+
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Pre-Init
+        if: env.TF_TMP_WORKSPACE != ''
+        run: |
+          terraform init -input=false \
+            ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
+            ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
+            ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
+
+      - name: Select/Create Terraform Workspace
+        if: env.TF_TMP_WORKSPACE != ''
+        run: |
+          echo "TF_WORKSPACE=$TF_TMP_WORKSPACE" >> $GITHUB_ENV
+          terraform workspace select $TF_TMP_WORKSPACE || terraform workspace new $TF_TMP_WORKSPACE
+
+      # Initialize again in case a new workspace was selected
+      - name: Terraform Init
+        id: init
+        run: |
+          terraform init -input=false \
+            ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
+            ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
+            ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
+
+      # Run terraform force-unlock if 'unlock' is set to true
+      - name: Terraform Unlock
+        if: env.UNLOCK != ''
+        id: unlock
+        run: |
+          terraform force-unlock -force $UNLOCK
+
+      - name: Terraform Validate
+        id: validate
+        run: |
+          echo 'Run validate' | tee $GITHUB_STEP_SUMMARY
+          terraform validate -no-color | tee -a output.txt
+          cat output.txt | sed '/^::/d' >> $GITHUB_STEP_SUMMARY
+
+      # Checks that all Terraform configuration files adhere to a canonical format
+      - name: Terraform Format
+        id: format
+
+        run: |
+          echo 'Run format check' | tee -a $GITHUB_STEP_SUMMARY
+          terraform fmt -check -recursive -no-color || { echo '
+          FAILURE! The above files are not properly formatted.
+          Run `terraform fmt` in $WORKING_DIRECTORY, commit the changed files and push to fix the issue' | tee -a $GITHUB_STEP_SUMMARY ; exit 1; }
+
+      - name: Check for PostgreSQL Provider
+        id: check_postgresql
+        run: |
+          PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
+          if [ -n "$PROVIDER_CHECK" ]; then
+            echo "PostgreSQL provider found."
+            echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
+          else
+            echo "PostgreSQL provider not found."
+            echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
+          fi
+
+      - name: Tailscale
+        if: env.NEED_TAILSCALE == 'true'
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
+          tags: tag:cloudsql-user
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          # 1. Run and send stdout to build log as usual
+          if [ "$DESTROY" == "true" ] 
+          then
+            terraform plan -destroy -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
+              ${TF_OPTION_1:+"$TF_OPTION_1"} \
+              ${TF_OPTION_2:+"$TF_OPTION_2"} \
+              ${TF_OPTION_3:+"$TF_OPTION_3"} \
+              | tee output.txt
+          else
+            terraform plan -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
+              ${TF_OPTION_1:+"$TF_OPTION_1"} \
+              ${TF_OPTION_2:+"$TF_OPTION_2"} \
+              ${TF_OPTION_3:+"$TF_OPTION_3"} \
+              | tee output.txt
+          fi  
+
+          # 2. Remove some github commands and fluff
+          # This removes any line containing "Reading...", "Read complete after", and "Refreshing state...", which are terraform lines spewed out during state reading
+          STDOUT="$(grep -v -E '(.*Reading\.\.\..*)|(.*Read complete after.*)|(.*Refreshing state\.\.\..*)' output.txt)"
+
+          # Insert cleaned output back into output.txt
+          echo "$STDOUT" > output.txt
+
+          # 3. Write to step summary
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          \`\`\`
+          ${STDOUT}
+          \`\`\`
+          EOF
+
+          # 4. Serialize into single-line string for transfer using outputs that only support single line
+          STDOUT="${STDOUT//'%'/'%25'}"
+          STDOUT="${STDOUT//$'\n'/'%0A'}"
+          STDOUT="${STDOUT//$'\r'/'%0D'}"
+
+          # 5. Write output 
+          echo "stdout=$STDOUT" >> $GITHUB_OUTPUT
+
+      - name: Upload Plan Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plan-${{ env.ENVIRONMENT }}.tfplan
+          path: ${{ env.WORKING_DIRECTORY }}/plan-${{ env.ENVIRONMENT }}.tfplan
+          retention-days: 5
+
+      - name: Update Pull Request
+        uses: actions/github-script@v7
+        if: (always() && inputs.add_comment_on_pr == true && github.event_name == 'pull_request')
         env:
-            # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
-            TF_IN_AUTOMATION: true
-            WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.workload_identity_provider }}
+          # Passing via env vars to sanitize untrusted inputs
+          VALIDATE_OUTPUT: ${{ steps.validate.outputs.stdout }}
+          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+          FORMAT_OUTCOME: ${{ steps.format.outcome}}
+          INIT_OUTCOME: ${{ steps.init.outcome }}
+          PLAN_EXITCODE: ${{ steps.plan.outputs.exitcode }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          PLAN_FILE: ${{ env.WORKING_DIRECTORY }}/output.txt
 
-        steps:
-            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
-              id: octo-sts
-              if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
-              with:
-                  scope: kartverket
-                  identity: kartverket_repos
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID;
+            const run_link = '<a href="' + run_url + '">Actions</a>.'
+            const fs = require('fs')
+            const plan_file = fs.readFileSync(process.env.PLAN_FILE, 'utf8')
+            const plan = plan_file.length > 65000 ? plan_file.toString().substring(0, 65000) + '...' : plan_file
+            const truncated_message = plan_file.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
 
-            # Checkout the repository to the GitHub Actions runner
-            - name: Checkout
-              uses: actions/checkout@v4
-              with:
-                  submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
-                  token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
+            const {
+              ENVIRONMENT,
+              PLAN_EXITCODE,
+              DEPLOY_ON,
+              VALIDATE_OUTPUT,
+              FORMAT_OUTCOME,
+              INIT_OUTCOME,
+              VALIDATE_OUTCOME,
+              PLAN_OUTCOME,
+              WORKING_DIRECTORY,
+            } = process.env;
 
-            - name: hack for github internal repo access
-              if: ${{ inputs.use_platform_modules == true }}
-              run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
+            /* Body is in the format of
+            * <!-- @run-terraform -->
+            * <!-- @run-terraform:start:jobid -->
+            * Output of job with id jobid
+            * <!-- @run-terraform:end:jobid -->
+            */
+            const bodyStartMarker = '<!-- @run-terraform -->';
+            const comment = comments.find(({ body }) => body.startsWith(bodyStartMarker));
+            const id = comment?.id;
+            let commentBody = comment?.body ?? bodyStartMarker;
+            const bodyHasJobInfo = commentBody.includes(`<!-- @run-terraform:start:${ENVIRONMENT} -->`);
 
-            # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-            - name: Setup Terraform
-              uses: hashicorp/setup-terraform@v3.1.2
-              with:
-                  terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
+            const exitcode = PLAN_EXITCODE;
+            const action = {
+              0: 'No changes detected. Will not run Terraform apply job',
+              1: 'An error occured! Will not run Terraform apply job',
+              2: `Changes detected. Will run Terraform apply job on merge to ${DEPLOY_ON}`
+            }[exitcode] ?? 'Terraform gave an unknown exit code, I don\'t know what happens next!';
 
-            - name: Authenticate with Google Cloud
-              uses: google-github-actions/auth@v2
-              with:
-                  workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-                  service_account: ${{ env.SERVICE_ACCOUNT }}
-                  project_id: ${{ env.PROJECT_ID }}
+            const jobBody = `<!-- @run-terraform:start:${ENVIRONMENT} -->
+            ## Results for ${ENVIRONMENT} ${exitcode === '2' ? '– ❗ `CHANGED` ❗' : ''}
+            #### Terraform Format and Style 🖌 \`${FORMAT_OUTCOME}\`
+            #### Terraform Initialization ⚙️ \`${INIT_OUTCOME}\`
+            #### Terraform Validation 🤖 \`${VALIDATE_OUTCOME}\`
+            <details><summary>Validation Output</summary>
 
-            # Install the Gcloud suite in order to install gke-gcloud-auth-plugin plugin
-            - name: Set up Cloud SDK
-              if: env.KUBERNETES_CLUSTER != ''
-              uses: google-github-actions/setup-gcloud@v2
+            \`\`\`\n
+            ${VALIDATE_OUTPUT}
+            \`\`\`
 
-            - name: Authenticate with Kubernetes
-              if: env.KUBERNETES_CLUSTER != ''
-              run: |
-                  gcloud components install gke-gcloud-auth-plugin
-                  gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
+            </details>
 
-            # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-            - name: Terraform Pre-Init
-              if: env.TF_TMP_WORKSPACE != ''
-              run: |
-                  terraform init -input=false \
-                    ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
-                    ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
-                    ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
+            #### Terraform Plan 📖 \`${PLAN_OUTCOME}\`
 
-            - name: Select/Create Terraform Workspace
-              if: env.TF_TMP_WORKSPACE != ''
-              run: |
-                  echo "TF_WORKSPACE=$TF_TMP_WORKSPACE" >> $GITHUB_ENV
-                  terraform workspace select $TF_TMP_WORKSPACE || terraform workspace new $TF_TMP_WORKSPACE
+            <details><summary>Show Plan</summary>
 
-            # Initialize again in case a new workspace was selected
-            - name: Terraform Init
-              id: init
-              run: |
-                  terraform init -input=false \
-                    ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
-                    ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
-                    ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
+            \`\`\`\n
+            ${plan}
+            \`\`\`
 
-            # Run terraform force-unlock if 'unlock' is set to true
-            - name: Terraform Unlock
-              if: env.UNLOCK != ''
-              id: unlock
-              run: |
-                  terraform force-unlock -force $UNLOCK
+            </details>
+            ${truncated_message}
 
-            - name: Terraform Validate
-              id: validate
-              run: |
-                  echo 'Run validate' | tee $GITHUB_STEP_SUMMARY
-                  terraform validate -no-color | tee -a output.txt
-                  cat output.txt | sed '/^::/d' >> $GITHUB_STEP_SUMMARY
+            #### Next action 🚀
+            ${action}
 
-            # Checks that all Terraform configuration files adhere to a canonical format
-            - name: Terraform Format
-              id: format
+            *Pusher: @${{ github.actor }}, Working Directory: \`${WORKING_DIRECTORY}\`, Commit: ${{ github.sha }}, Generated at: \`${new Date().toLocaleString('nb')}\`*
+            <!-- @run-terraform:end:${ENVIRONMENT} -->`;
 
-              run: |
-                  echo 'Run format check' | tee -a $GITHUB_STEP_SUMMARY
-                  terraform fmt -check -recursive -no-color || { echo '
-                  FAILURE! The above files are not properly formatted.
-                  Run `terraform fmt` in $WORKING_DIRECTORY, commit the changed files and push to fix the issue' | tee -a $GITHUB_STEP_SUMMARY ; exit 1; }
+            if (bodyHasJobInfo) {
+              commentBody = commentBody.replace(
+                new RegExp(`<!-- @run-terraform:start:${ENVIRONMENT} -->.*<!-- @run-terraform:end:${ENVIRONMENT} -->`, 's'),
+                jobBody,
+              );
+            } else {
+              commentBody += '\n' + jobBody;
+            }
 
-            - name: Check for PostgreSQL Provider
-              id: check_postgresql
-              run: |
-                  PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
-                  if [ -n "$PROVIDER_CHECK" ]; then
-                    echo "PostgreSQL provider found."
-                    echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
-                  else
-                    echo "PostgreSQL provider not found."
-                    echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
-                  fi
+            commentBody = commentBody
+              .replaceAll("%0A", "\n")
+              .replaceAll("%0D", "\n");
 
-            - name: Tailscale
-              if: env.NEED_TAILSCALE == 'true'
-              uses: tailscale/github-action@v3
-              with:
-                  oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
-                  oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
-                  tags: tag:cloudsql-user
+            if (id) {
+              github.rest.issues.updateComment({
+                comment_id: id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              })
+            }
 
-            - name: Terraform Plan
-              id: plan
-              run: |
-                  # 1. Run and send stdout to build log as usual
-                  if [ "$DESTROY" == "true" ] 
-                  then
-                    terraform plan -destroy -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
-                      ${TF_OPTION_1:+"$TF_OPTION_1"} \
-                      ${TF_OPTION_2:+"$TF_OPTION_2"} \
-                      ${TF_OPTION_3:+"$TF_OPTION_3"} \
-                      | tee output.txt
-                  else
-                    terraform plan -input=false -no-color -detailed-exitcode -out=plan-$ENVIRONMENT.tfplan \
-                      ${TF_OPTION_1:+"$TF_OPTION_1"} \
-                      ${TF_OPTION_2:+"$TF_OPTION_2"} \
-                      ${TF_OPTION_3:+"$TF_OPTION_3"} \
-                      | tee output.txt
-                  fi  
+  run_terraform:
+    needs: [setup-env, terraform_plan]
+    if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
+    name: Terraform Apply or Destroy
+    runs-on: ${{ inputs.runner }}
+    environment: ${{ inputs.environment }}
+    outputs:
+      tf_outputs: ${{ steps.extract.outputs.tf_outputs || '{}' }}
 
-                  # 2. Remove some github commands and fluff
-                  # This removes any line containing "Reading...", "Read complete after", and "Refreshing state...", which are terraform lines spewed out during state reading
-                  STDOUT="$(grep -v -E '(.*Reading\.\.\..*)|(.*Read complete after.*)|(.*Refreshing state\.\.\..*)' output.txt)"
+    # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
+    concurrency: ${{ inputs.environment }}
 
-                  # Insert cleaned output back into output.txt
-                  echo "$STDOUT" > output.txt
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ env.WORKING_DIRECTORY }}
 
-                  # 3. Write to step summary
-                  cat >> $GITHUB_STEP_SUMMARY <<EOF
-                  \`\`\`
-                  ${STDOUT}
-                  \`\`\`
-                  EOF
+    env:
+      # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
+      TF_IN_AUTOMATION: true
+      TF_WORKSPACE: ${{ inputs.terraform_workspace }}
+      WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
 
-                  # 4. Serialize into single-line string for transfer using outputs that only support single line
-                  STDOUT="${STDOUT//'%'/'%25'}"
-                  STDOUT="${STDOUT//$'\n'/'%0A'}"
-                  STDOUT="${STDOUT//$'\r'/'%0D'}"
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
+        with:
+          scope: kartverket
+          identity: kartverket_repos
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
+          token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
 
-                  # 5. Write output 
-                  echo "stdout=$STDOUT" >> $GITHUB_OUTPUT
+      - name: hack for github internal repo access
+        if: ${{ inputs.use_platform_modules == true }}
+        run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
 
-            - name: Upload Plan Artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: plan-${{ env.ENVIRONMENT }}.tfplan
-                  path: ${{ env.WORKING_DIRECTORY }}/plan-${{ env.ENVIRONMENT }}.tfplan
-                  retention-days: 5
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+        with:
+          terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
 
-            - name: Update Pull Request
-              uses: actions/github-script@v7
-              if: (always() && inputs.add_comment_on_pr == true && github.event_name == 'pull_request')
-              env:
-                  # Passing via env vars to sanitize untrusted inputs
-                  VALIDATE_OUTPUT: ${{ steps.validate.outputs.stdout }}
-                  VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
-                  FORMAT_OUTCOME: ${{ steps.format.outcome}}
-                  INIT_OUTCOME: ${{ steps.init.outcome }}
-                  PLAN_EXITCODE: ${{ steps.plan.outputs.exitcode }}
-                  PLAN_OUTCOME: ${{ steps.plan.outcome }}
-                  PLAN_FILE: ${{ env.WORKING_DIRECTORY }}/output.txt
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          project_id: ${{ env.PROJECT_ID }}
 
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  script: |
-                      const run_url = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID;
-                      const run_link = '<a href="' + run_url + '">Actions</a>.'
-                      const fs = require('fs')
-                      const plan_file = fs.readFileSync(process.env.PLAN_FILE, 'utf8')
-                      const plan = plan_file.length > 65000 ? plan_file.toString().substring(0, 65000) + '...' : plan_file
-                      const truncated_message = plan_file.length > 65000 ? "Output is too long and was truncated. You can read full Plan in " + run_link + "<br /><br />" : ""
-                      const { data: comments } = await github.rest.issues.listComments({
-                        issue_number: context.issue.number,
-                        owner: context.repo.owner,
-                        repo: context.repo.repo
-                      });
+      - name: Set up Cloud SDK
+        if: env.KUBERNETES_CLUSTER != ''
+        uses: google-github-actions/setup-gcloud@v2
 
-                      const {
-                        ENVIRONMENT,
-                        PLAN_EXITCODE,
-                        DEPLOY_ON,
-                        VALIDATE_OUTPUT,
-                        FORMAT_OUTCOME,
-                        INIT_OUTCOME,
-                        VALIDATE_OUTCOME,
-                        PLAN_OUTCOME,
-                        WORKING_DIRECTORY,
-                      } = process.env;
+      - name: Authenticate with Kubernetes
+        if: env.KUBERNETES_CLUSTER != ''
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+          gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
 
-                      /* Body is in the format of
-                      * <!-- @run-terraform -->
-                      * <!-- @run-terraform:start:jobid -->
-                      * Output of job with id jobid
-                      * <!-- @run-terraform:end:jobid -->
-                      */
-                      const bodyStartMarker = '<!-- @run-terraform -->';
-                      const comment = comments.find(({ body }) => body.startsWith(bodyStartMarker));
-                      const id = comment?.id;
-                      let commentBody = comment?.body ?? bodyStartMarker;
-                      const bodyHasJobInfo = commentBody.includes(`<!-- @run-terraform:start:${ENVIRONMENT} -->`);
+      - name: Download Plan Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: plan-${{ env.ENVIRONMENT }}.tfplan
+          path: ${{ env.WORKING_DIRECTORY }}
 
-                      const exitcode = PLAN_EXITCODE;
-                      const action = {
-                        0: 'No changes detected. Will not run Terraform apply job',
-                        1: 'An error occured! Will not run Terraform apply job',
-                        2: `Changes detected. Will run Terraform apply job on merge to ${DEPLOY_ON}`
-                      }[exitcode] ?? 'Terraform gave an unknown exit code, I don\'t know what happens next!';
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Init
+        run: |
+          terraform init -input=false \
+            ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
+            ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
+            ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
 
-                      const jobBody = `<!-- @run-terraform:start:${ENVIRONMENT} -->
-                      ## Results for ${ENVIRONMENT} ${exitcode === '2' ? '– ❗ `CHANGED` ❗' : ''}
-                      #### Terraform Format and Style 🖌 \`${FORMAT_OUTCOME}\`
-                      #### Terraform Initialization ⚙️ \`${INIT_OUTCOME}\`
-                      #### Terraform Validation 🤖 \`${VALIDATE_OUTCOME}\`
-                      <details><summary>Validation Output</summary>
+      - name: Check for PostgreSQL Provider
+        id: check_postgresql
+        run: |
+          PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
+          if [ -n "$PROVIDER_CHECK" ]; then
+            echo "PostgreSQL provider found."
+            echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
+          else
+            echo "PostgreSQL provider not found."
+            echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
+          fi
 
-                      \`\`\`\n
-                      ${VALIDATE_OUTPUT}
-                      \`\`\`
+      - name: Tailscale
+        if: env.NEED_TAILSCALE == 'true'
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
+          tags: tag:cloudsql-user
 
-                      </details>
+      # Run terraform destroy on push to main if 'destroy' is set to true
+      - name: Terraform Destroy
+        if: env.DESTROY == 'true'
+        id: destroy
+        run: |
+          terraform destroy -auto-approve \
+            ${TF_OPTION_1:+"$TF_OPTION_1"} \
+            ${TF_OPTION_2:+"$TF_OPTION_2"} \
+            ${TF_OPTION_3:+"$TF_OPTION_3"}
 
-                      #### Terraform Plan 📖 \`${PLAN_OUTCOME}\`
+      - name: Run Terraform
+        if: env.DESTROY == 'false'
+        run: terraform apply -input=false plan-$ENVIRONMENT.tfplan
 
-                      <details><summary>Show Plan</summary>
+      - name: Extract Terraform Outputs
+        if: env.EXTRACT_TERRAFORM_OUTPUTS != ''
+        id: extract
+        run: |
+          OUTPUTS=$(terraform output -json)
+          REQUESTED_OUTPUTS="${{ env.EXTRACT_TERRAFORM_OUTPUTS }}"
+          JQ_KEYS=$(echo "$REQUESTED" | awk -F',' '{for(i=1;i<=NF;i++) printf "\"%s\": .%s,", $i, $i}' | sed 's/,$//')
 
-                      \`\`\`\n
-                      ${plan}
-                      \`\`\`
+          FILTERED=$(echo "$OUTPUTS" | jq "{ $JQ_KEYS }")
+          echo "tf_outputs=$FILTERED" >> $GITHUB_OUTPUT
 
-                      </details>
-                      ${truncated_message}
-
-                      #### Next action 🚀
-                      ${action}
-
-                      *Pusher: @${{ github.actor }}, Working Directory: \`${WORKING_DIRECTORY}\`, Commit: ${{ github.sha }}, Generated at: \`${new Date().toLocaleString('nb')}\`*
-                      <!-- @run-terraform:end:${ENVIRONMENT} -->`;
-
-                      if (bodyHasJobInfo) {
-                        commentBody = commentBody.replace(
-                          new RegExp(`<!-- @run-terraform:start:${ENVIRONMENT} -->.*<!-- @run-terraform:end:${ENVIRONMENT} -->`, 's'),
-                          jobBody,
-                        );
-                      } else {
-                        commentBody += '\n' + jobBody;
-                      }
-
-                      commentBody = commentBody
-                        .replaceAll("%0A", "\n")
-                        .replaceAll("%0D", "\n");
-
-                      if (id) {
-                        github.rest.issues.updateComment({
-                          comment_id: id,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          body: commentBody
-                        })
-                      } else {
-                        github.rest.issues.createComment({
-                          issue_number: context.issue.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          body: commentBody
-                        })
-                      }
-
-    run_terraform:
-        needs: [setup-env, terraform_plan]
-        if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') || (github.ref == inputs.deploy_on || github.ref_name == inputs.deploy_on)) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (needs.terraform_plan.outputs.plan_exitcode == '2' || inputs.destroy == true)
-        name: Terraform Apply or Destroy
-        runs-on: ${{ inputs.runner }}
-        environment: ${{ inputs.environment }}
-        outputs:
-            tf_outputs: ${{ steps.extract.outputs.tf_outputs || '{}' }}
-
-        # Disallow parallel jobs for same env to allow aquiring state lock instead of crashing
-        concurrency: ${{ inputs.environment }}
-
-        # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-        defaults:
-            run:
-                shell: bash
-                working-directory: ${{ env.WORKING_DIRECTORY }}
-
-        env:
-            # makes some minor adjustments to Terraforms output to de-emphasize specific commands to run
-            TF_IN_AUTOMATION: true
-            TF_WORKSPACE: ${{ inputs.terraform_workspace }}
-            WORKLOAD_IDENTITY_PROVIDER: ${{ needs.setup-env.outputs.WORKLOAD_IDENTITY_PROVIDER }}
-
-        steps:
-            - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
-              id: octo-sts
-              if: ${{ inputs.use_platform_modules == true || inputs.checkout_submodules == true}}
-              with:
-                  scope: kartverket
-                  identity: kartverket_repos
-            # Checkout the repository to the GitHub Actions runner
-            - name: Checkout
-              uses: actions/checkout@v4
-              with:
-                  submodules: ${{ inputs.checkout_submodules == true && 'recursive' || 'false' }}
-                  token: ${{ inputs.checkout_submodules == true && steps.octo-sts.outputs.token || github.token }}
-
-            - name: hack for github internal repo access
-              if: ${{ inputs.use_platform_modules == true }}
-              run: git config --global url."https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com".insteadOf ssh://git@github.com
-
-            # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-            - name: Setup Terraform
-              uses: hashicorp/setup-terraform@v3.1.2
-              with:
-                  terraform_version: ${{ inputs.use_platform_modules == true && '1.6.6' || 'latest' }}
-
-            - name: Authenticate with Google Cloud
-              uses: google-github-actions/auth@v2
-              with:
-                  workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-                  service_account: ${{ env.SERVICE_ACCOUNT }}
-                  project_id: ${{ env.PROJECT_ID }}
-
-            - name: Set up Cloud SDK
-              if: env.KUBERNETES_CLUSTER != ''
-              uses: google-github-actions/setup-gcloud@v2
-
-            - name: Authenticate with Kubernetes
-              if: env.KUBERNETES_CLUSTER != ''
-              run: |
-                  gcloud components install gke-gcloud-auth-plugin
-                  gcloud container hub memberships get-credentials $KUBERNETES_CLUSTER --verbosity debug --location global
-
-            - name: Download Plan Artifact
-              uses: actions/download-artifact@v4
-              with:
-                  name: plan-${{ env.ENVIRONMENT }}.tfplan
-                  path: ${{ env.WORKING_DIRECTORY }}
-
-            # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-            - name: Terraform Init
-              run: |
-                  terraform init -input=false \
-                    ${TF_INIT_OPTION_1:+"$TF_INIT_OPTION_1"} \
-                    ${TF_INIT_OPTION_2:+"$TF_INIT_OPTION_2"} \
-                    ${TF_INIT_OPTION_3:+"$TF_INIT_OPTION_3"}
-
-            - name: Check for PostgreSQL Provider
-              id: check_postgresql
-              run: |
-                  PROVIDER_CHECK=$(terraform providers | grep cyrilgdn/postgresql) || true
-                  if [ -n "$PROVIDER_CHECK" ]; then
-                    echo "PostgreSQL provider found."
-                    echo "NEED_TAILSCALE=true" >> $GITHUB_ENV
-                  else
-                    echo "PostgreSQL provider not found."
-                    echo "NEED_TAILSCALE=false" >> $GITHUB_ENV
-                  fi
-
-            - name: Tailscale
-              if: env.NEED_TAILSCALE == 'true'
-              uses: tailscale/github-action@v3
-              with:
-                  oauth-client-id: ${{ secrets.TS_CLOUDSQL_OAUTH_CLIENT_ID }}
-                  oauth-secret: ${{ secrets.TS_CLOUDSQL_OAUTH_SECRET }}
-                  tags: tag:cloudsql-user
-
-            # Run terraform destroy on push to main if 'destroy' is set to true
-            - name: Terraform Destroy
-              if: env.DESTROY == 'true'
-              id: destroy
-              run: |
-                  terraform destroy -auto-approve \
-                    ${TF_OPTION_1:+"$TF_OPTION_1"} \
-                    ${TF_OPTION_2:+"$TF_OPTION_2"} \
-                    ${TF_OPTION_3:+"$TF_OPTION_3"}
-
-            - name: Run Terraform
-              if: env.DESTROY == 'false'
-              run: terraform apply -input=false plan-$ENVIRONMENT.tfplan
-
-            - name: Extract Terraform Outputs
-              if: env.EXTRACT_TERRAFORM_OUTPUTS != ''
-              id: extract
-              run: |
-                  OUTPUTS=$(terraform output -json)
-                  REQUESTED_OUTPUTS="${{ env.EXTRACT_TERRAFORM_OUTPUTS }}"
-                  JQ_KEYS=$(echo "$REQUESTED" | awk -F',' '{for(i=1;i<=NF;i++) printf "\"%s\": .%s,", $i, $i}' | sed 's/,$//')
-
-                  FILTERED=$(echo "$OUTPUTS" | jq "{ $JQ_KEYS }")
-                  echo "tf_outputs=$FILTERED" >> $GITHUB_OUTPUT
-
-            - name: Upload output artifact
-              if: ${{ inputs.output_file_path != '' }}
-              uses: actions/upload-artifact@v4
-              with:
-                  name: output-file
-                  path: ${{ inputs.output_file_path }}
+      - name: Upload output artifact
+        if: ${{ inputs.output_file_path != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: output-file
+          path: ${{ inputs.output_file_path }}


### PR DESCRIPTION
Forslag til utvidelse av den gjenbrukbare workflowen `run-terraform.yml`, der brukeren kan sende inn et sett med ønskede verdier som skal outputtes fra Terraform slik at de kan bli brukt videre av andre jobber. 

Behovet kommer fra å gjøre den selvbetjente onboardingen til DASK enda mer automatisert ved å hente ut `project_id` og `project_number`, for deretter å publisere det på en PubSub. 

