### PR TITLE
feat: add `Run Kubernetes Manifest Validate` action

### DIFF
--- a/.github/workflows/run-k8s-manifests-validate.yaml
+++ b/.github/workflows/run-k8s-manifests-validate.yaml
@@ -16,41 +16,17 @@ jobs:
   validate:
     name: Validate k8s manifests
     runs-on: ubuntu-latest
-    env:
-      SKIPCTL_VERSION: ${{ inputs.skipctl-version }}
-      GO_VERSION: '1.25.1'
 
     steps:
       - name: Checkout calling repository code
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Create `~/go/bin` directory for caching purposes
-        run: mkdir -p ~/go/bin
-
-      - name: Get `skipctl` version ${{ env.SKIPCTL_VERSION }}
-        id: get-version
-        run: |
-          if [ "$SKIPCTL_VERSION" = "latest" ]; then
-            echo "version=$(curl -s https://api.github.com/repos/kartverket/skipctl/releases/latest | jq -r .tag_name)" >> $GITHUB_OUTPUT
-          else
-            echo "version=$SKIPCTL_VERSION" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Cache `skipctl` binary
-        id: cache-skipctl
-        uses: actions/cache@v4
-        with:
-          path: ~/go/bin/skipctl
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-skipctl-${{ steps.get-version.outputs.version }}
-
-      - name: Install `skipctl`
-        if: steps.cache-skipctl.outputs.cache-hit != 'true'
-        run: go install github.com/kartverket/skipctl@${{ steps.get-version.outputs.version }}
+      - name: Install `skipctl` @ ${{ inputs.skipctl-version }}
+        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        with: 
+          repo: kartverket/skipctl
+          tag: ${{ inputs.skipctl-version }}
+          cache: enable
 
       - name: Run manifests validation
         run: |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ jobs:
 Runs validation of Kubernetes manifest files using Skiperators custom resource definitions (CRDs). 
 Useful not only to check for correct syntax in `yaml` and `jsonnet` files, but to validate that all required fields are included and are of correct type.
 Uses `skipctl` under the hood. For more info see the [`skipctl` documentation](https://github.com/kartverket/skipctl/).
-The workflow implements per-repo caching, meaning `skipctl` is cached as a dependency and only installed once per each combination of OS + go version + `skipctl` version.
 
 ### Features
 


### PR DESCRIPTION
This PR introduces a `Verify Kubernetes Manifest Validity` action which validates JSON k8s manifests with custom resource definitions. The CRDs of NAIS (nais.io), External-Secrets (external-secrets.io), Istio (istio.io), and Skiperator (github.com/kartverket/skiperator) are applied to allow for custom validation. The `skipctl` package is installed and used to perform the validation on the `path` input variable of the imported repo, which can be either a file or a directory. Default is set to `env` directory to facilitate the `apps` repo structure.

### Changelog:
- added `jaxxstorm/action-install-gh-release` to handle dynamic download, extraction and caching of `skipctl` binary
- run `skipctl manifests validate` command
- add documentation and specs on how to use workflow

### Screenshots:
**Unsuccessful pipeline (~5-10 seconds)**
<img width="1171" height="475" alt="Screenshot 2025-09-11 at 09 14 56" src="https://github.com/user-attachments/assets/1349a778-14e5-481c-94d2-ada9a7ad7547" />

**Successful pipeline (~5-10 seconds)**
<img width="1155" height="385" alt="Screenshot 2025-09-11 at 09 13 46" src="https://github.com/user-attachments/assets/5888bb02-4efa-4b8b-9e0f-64e4eeb38416" />

![ship-mar-gif-by-maria-jose-guzman](https://github.com/user-attachments/assets/74632033-360d-4198-88c8-56d87d735842)

