### PR TITLE
K8s validation workflow improvements

### DIFF
--- a/.github/workflows/run-k8s-manifests-validate.yaml
+++ b/.github/workflows/run-k8s-manifests-validate.yaml
@@ -13,7 +13,7 @@ on:
         default: latest
 env:
   MANIFESTS_PATH: ${{ inputs.path }}
-  ACTION_INSTALL_SHA: b3473ce464694a09adb7b66ed3cf1ae01a9b9c17
+  ACTION_INSTALL_SHA: 6096f2a2bbfee498ced520b6922ac2c06e990ed2
 
 jobs:
   validate:

--- a/.github/workflows/run-k8s-manifests-validate.yaml
+++ b/.github/workflows/run-k8s-manifests-validate.yaml
@@ -24,7 +24,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Install `skipctl` @ ${{ inputs.skipctl-version }}
         uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0

--- a/.github/workflows/run-k8s-manifests-validate.yaml
+++ b/.github/workflows/run-k8s-manifests-validate.yaml
@@ -13,7 +13,6 @@ on:
         default: latest
 env:
   MANIFESTS_PATH: ${{ inputs.path }}
-  ACTION_INSTALL_SHA: 6096f2a2bbfee498ced520b6922ac2c06e990ed2
 
 jobs:
   validate:
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install `skipctl` @ ${{ inputs.skipctl-version }}
-        uses: jaxxstorm/action-install-gh-release@ACTION_INSTALL_SHA # v2.1.0
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
         with:
           repo: kartverket/skipctl
           tag: ${{ inputs.skipctl-version }}

--- a/.github/workflows/run-k8s-manifests-validate.yaml
+++ b/.github/workflows/run-k8s-manifests-validate.yaml
@@ -3,14 +3,17 @@ name: Run Kubernetes Manifests Validate
 on:
   workflow_call:
     inputs:
-      path: 
+      path:
         type: string
         description: "Path to file or directory in which to look for manifests to validate (default: env)"
         default: env
-      skipctl-version: 
+      skipctl-version:
         type: string
         description: "Which version of `skipctl` to use (default: latest)"
         default: latest
+env:
+  MANIFESTS_PATH: ${{ inputs.path }}
+  ACTION_INSTALL_SHA: b3473ce464694a09adb7b66ed3cf1ae01a9b9c17
 
 jobs:
   validate:
@@ -22,12 +25,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install `skipctl` @ ${{ inputs.skipctl-version }}
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
-        with: 
+        uses: jaxxstorm/action-install-gh-release@ACTION_INSTALL_SHA # v2.1.0
+        with:
           repo: kartverket/skipctl
           tag: ${{ inputs.skipctl-version }}
           cache: enable
 
       - name: Run manifests validation
         run: |
-          skipctl manifests validate --path=${{ inputs.path }}
+          skipctl manifests validate --path="$MANIFESTS_PATH"

--- a/.github/workflows/run-k8s-manifests-validate.yaml
+++ b/.github/workflows/run-k8s-manifests-validate.yaml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout calling repository code
         uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
 
       - name: Install `skipctl` @ ${{ inputs.skipctl-version }}
         uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0


### PR DESCRIPTION
# 🔒️ Security and usability improvements

I used the `zizmor` tool to scan the workflow for issues, these are adressed in this PR.
There was also a bug where validation did not work for files with imported libsonnet files in submodules (argokit)

**Changes**
- Pin the version to SHA of external action jaxxstorm/action-install-gh-release
- Have command line argument as env variable to avoid injection attacks
- Also checkout submodule to include argokit for users with this installed as submodule