### PR TITLE
feat: Add merge type as option to auto-merge-dependabot

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -86,6 +86,13 @@ jobs:
           set -e
           sleep 10
 
+          echo "Validating merge method..."
+          if [[ ! "$MERGE_METHOD" =~ ^(merge|squash|rebase)$ ]]; then
+            echo "❌ Invalid merge method: $MERGE_METHOD. Must be one of: merge, squash, rebase."
+            exit 1
+          fi
+          echo "✅ Valid merge method: $MERGE_METHOD"
+
           echo "Check if PR is mergeable..."
           mergeable=$(gh pr view "$PR_URL" --json mergeable --jq '.mergeable')
 

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -14,21 +14,24 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v6
+
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-            scope: ${{ github.repository }}
-            identity: auto-update
+          scope: ${{ github.repository }}
+          identity: auto-update
+
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2
+
       - name: Read configfile
         id: read-configfile
         uses: actions/github-script@v8
         env:
-            DEPENDENCY_NAMES: ${{steps.dependabot-metadata.outputs.dependency-names}}
-            UPDATE_TYPE: ${{steps.dependabot-metadata.outputs.update-type}}
-            PACKAGE_ECOSYSTEM: ${{steps.dependabot-metadata.outputs.package-ecosystem}}
+          DEPENDENCY_NAMES: ${{steps.dependabot-metadata.outputs.dependency-names}}
+          UPDATE_TYPE: ${{steps.dependabot-metadata.outputs.update-type}}
+          PACKAGE_ECOSYSTEM: ${{steps.dependabot-metadata.outputs.package-ecosystem}}
         with:
           script: |
             const fs = require('fs');
@@ -36,7 +39,7 @@ jobs:
             const dependencyNames = DEPENDENCY_NAMES?.split();
             console.log({ dependencyNames, UPDATE_TYPE, PACKAGE_ECOSYSTEM })
                         
-            // [{ match: { dependency_name: "..", update_type: "semver:.."}}]
+            // [{ match: { dependency_name: "..", update_type: "semver:..", merge_method: ".."}}]
             const data = fs.readFileSync(CONFIG_FILE, 'utf8');
             if (!data) return false;
             let json;
@@ -45,32 +48,42 @@ jobs:
             } catch (e) {
               console.error('Failed to parse configfile ' + CONFIG_FILE);
               throw e;
-            }
-            
-            // Set this to true if we find a matching dependency update
-            const shouldMerge = !!json?.some(({ match }) => {
-                if (!dependencyNames?.includes(match?.dependency_name) && !(PACKAGE_ECOSYSTEM?.includes(match?.package_ecosystem))) return false;
-                switch (match?.update_type) {
-                  // Fallthrough until we hit a result. Major also matches minor and so on.
-                  case 'semver:major': if (UPDATE_TYPE === 'version-update:semver-major') return true;
-                  case 'semver:minor': if (UPDATE_TYPE === 'version-update:semver-minor') return true;
-                  case 'semver:patch': if (UPDATE_TYPE === 'version-update:semver-patch') return true;
-                  default: return false;
-                }
-            });
+            };
 
-            console.log({ shouldMerge });
-            return shouldMerge;
+            // Find matching dependency update and desired merge type:
+            let shouldMerge = false;
+            let mergeMethod = 'merge';
+
+            for (const { match } of json) {
+              const dependencyMatches = dependencyNames?.includes(match?.dependency_name);
+              const ecosystemMatches = PACKAGE_ECOSYSTEM?.includes(match?.package_ecosystem);
+
+              if (!dependencyMatches || !ecosystemMatches) continue;
+
+              if (`version-update:${match?.update_type}` === UPDATE_TYPE) {
+                shouldMerge = true;
+                mergeMethod = match?.merge_method || 'merge';
+                break;
+              }
+            };
+
+            console.log({ shouldMerge, mergeMethod });
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `should-merge=${shouldMerge}\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `merge-method=${mergeMethod}\n`);
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{fromJSON(steps.read-configfile.outputs.result)}}
+        if: ${{ steps.read-configfile.outputs.should-merge == 'true' }}
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          MERGE_METHOD: ${{steps.read-configfile.outputs.merge-method}}
         run: |
           set -e
           sleep 10
-          
+
           echo "Check if PR is mergeable..."
           mergeable=$(gh pr view "$PR_URL" --json mergeable --jq '.mergeable')
-  
+
           case "$mergeable" in
             MERGEABLE)
               echo "✅ No merge conflicts."
@@ -84,38 +97,38 @@ jobs:
               exit 1
               ;;
           esac
-  
+
           echo "Waiting for all checks to complete..."
 
           while true; do
             # Get all check runs excluding "Dependabot auto-merge"
             checks=$(gh pr checks "$PR_URL" --json workflow,state --jq '[.[] | select(.workflow != "Dependabot auto-merge")]')
-          
+
             # Extract all states
             states=$(echo "$checks" | jq -r '.[].state')
-          
+
             echo "Current check states: $states"
-          
+
             if echo "$states" | grep -q 'FAILURE'; then
               echo "❌ One or more checks failed."
               exit 1
             fi
-          
+
             if echo "$states" | grep -Eq 'PENDING|IN_PROGRESS|QUEUED'; then
               echo "🔄 Checks still running. Sleeping 10s..."
               sleep 10
               continue
             fi
-          
+
             if echo "$states" | grep -Ev '^(SUCCESS|SKIPPED|NEUTRAL)$' | grep -q .; then
               echo "⚠️ Unknown or unexpected check state detected. Failing."
               exit 1
             fi
-          
+
             echo "✅ All checks succeeded."
             break
           done
-          
+
           echo "Checking if any terraform changes are present..."
           tf_bot_commented_changes=$(gh pr view "$PR_URL" --json comments \
               --jq '.comments
@@ -124,22 +137,19 @@ jobs:
                     | contains("Changes detected.")')
             
           echo "Terraform changes detected: $tf_bot_commented_changes"
-          
+
           if [[ "$tf_bot_commented_changes" == "true" ]]; then
             echo "❌ Changes detected in Terraform plan. Aborting merge."
             exit 1
           else
             echo "✅ No changes detected. Proceeding."
           fi
-          
+
           echo "Approving PR..."
           gh pr review --approve -b "Dependency matches pattern found in auto-merge config, merging" "$PR_URL"
-      
-          echo "Attempting to merge directly..."
-          if ! gh pr merge --admin --merge "$PR_URL"; then
+
+          echo "Attempting to merge directly with method «${MERGE_METHOD}»..."
+          if ! gh pr merge --admin --${MERGE_METHOD} "$PR_URL"; then
             echo "Direct merge failed — adding to merge queue instead..."
-            gh pr merge --merge "$PR_URL"
+            gh pr merge --${MERGE_METHOD} "$PR_URL"
           fi
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -54,13 +54,18 @@ jobs:
             let shouldMerge = false;
             let mergeMethod = 'merge';
 
+            const levelMap = { major: 3, minor: 2, patch: 1 };
+
             for (const { match } of json) {
-              const dependencyMatches = dependencyNames?.includes(match?.dependency_name);
               const ecosystemMatches = PACKAGE_ECOSYSTEM?.includes(match?.package_ecosystem);
+              const dependencyMatches = dependencyNames?.includes(match?.dependency_name);
 
-              if (!dependencyMatches || !ecosystemMatches) continue;
+              if (!ecosystemMatches && !dependencyMatches) continue;
 
-              if (`version-update:${match?.update_type}` === UPDATE_TYPE) {
+              const configLevel = match?.update_type?.split(':')[1];
+              const updateLevel = UPDATE_TYPE?.split(':')[1]?.replace('semver-', '');
+
+              if (levelMap[configLevel] >= levelMap[updateLevel]) {
                 shouldMerge = true;
                 mergeMethod = match?.merge_method || 'merge';
                 break;

--- a/README.md
+++ b/README.md
@@ -181,13 +181,14 @@ jobs:
 
 ## auto-merge-dependabot
 
-Allows auto-merging dependabot PRs that match given patterns. Useful when you are drowning in PRs and have built up trust in a set of dependencies that release often and never break. It's recommended to have a sane CI setup so that anything merged to main at least passes CI tests before going into prod
+Allows auto-merging dependabot PRs that match given patterns. Useful when you are drowning in PRs and have built up trust in a set of dependencies that release often and never break.
+It's recommended to have a sane CI setup so that anything merged to main at least passes CI tests before going into prod
 
 ### Features
 
 - Allows configuring a set of dependencies in a configfile that can be merged
-- Can also configure ecosystems to merge automatically, for example go_modules
-- Each dependency will allow either major, minor or patch updates (only supports semver)
+- Can also configure ecosystems to merge automatically, for example `go_modules`
+- Each dependency will allow either major, minor or patch updates (only supports `semver`)
 - A bot approves and merges the PR
 
 ### Requirements
@@ -197,8 +198,8 @@ A few requirements are necessary in order to make this work in addition to the e
 1. Legacy branch protection rules are not supported. Your repo needs to use the more modern branch rulesets
 2. The Octo STS app needs to be added to the rulesets bypass list so that it can merge the PR
 3. A trust file called `.github/chainguard/auto-update.sts.yaml` needs to exist to allow the workflow to get a valid GitHub token
-4. If you use branch protection rules, and `Restrict who can push to matching branches` is checked, then you must add the octo-sts app to the allowlist.
-5. If you use branch protection rules, and `Require a pull request before merging` is checked, then you must add octo-sts to `Allow specified actors to bypass required pull requests`.
+4. If you use branch protection rules, and *Restrict who can push to matching branches* is checked, then you must add the octo-sts app to the allowlist.
+5. If you use branch protection rules, and *Require a pull request before merging* is checked, then you must add octo-sts to *Allow specified actors to bypass required pull requests*.
 
 ### Example
 
@@ -220,24 +221,28 @@ jobs:
 Example configfile in `.github/auto-merge.json`:
 
 ```json
-[{
-  "match": {
-    "dependency_name": "hashicorp/google",
-    "update_type": "semver:minor"
-  }
-},
+[
   {
     "match": {
+      "dependency_name": "hashicorp/google",
+      "update_type": "semver:minor"
+    }
+  },
+  {
+    "match": {
+      "merge_method": "rebase",
       "dependency_name": "hashicorp/google-beta",
       "update_type": "semver:minor"
     }
   },
   {
-   "match": {
-     "package_ecosystem": "golang",
-     "update_type": "semver:minor"
-   }
-}]
+    "match": {
+      "merge_method": "squash",
+      "package_ecosystem": "golang",
+      "update_type": "semver:minor"
+    }
+  }
+]
 ```
 
 Example STS trust file in `.github/chainguard/auto-update.sts.yaml`:
@@ -257,11 +262,12 @@ permissions:
 
 The configfile is currently the only input. The configfile at `.github/auto-merge.json` supports the following values:
 
-| Key                          | Type   | Required | Description                                                                                                                                                                                |
-|------------------------------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `[].match.dependency_name`   | string | true     | The name of the dependency as it appears on the Dependabot PR                                                                                                                              |
-| `[].match.update_type`       | string | true     | Which changes should be merged. Currently supports `semver:patch`, `semver:minor` and `semver:major`. The type includes all lower tiers, for example `semver:minor` includes patch changes |
-| `[].match.package_ecosystem` | string | true     | The name of the package ecosystem which the update belongs to, examples; terraform, golang                                                                                                 |
+| Key | Type | Required | Description |
+| --- | --- | --- | --- |
+| `[].match.dependency_name` | string | true | The name of the dependency as it appears on the Dependabot PR |
+| `[].match.update_type` | string | true | Which changes should be merged. Currently supports `semver:patch`, `semver:minor` and `semver:major`. The type includes all lower tiers, for example `semver:minor` includes patch changes |
+| `[].match.package_ecosystem` | string | true | The name of the package ecosystem which the update belongs to, examples; terraform, golang |
+| `[].match.merge_method` | string | false | Git merge method. One of: `merge`, `squash`, `rebase`. Defaults to `merge` |
 
 ## update-skip-docs
 


### PR DESCRIPTION
This pull request proposes an adjustment to the *Dependabot auto-merge* workflow so that the `gh pr merge` command at the end is not fixed with the flag `--merge`, but rather lets the user choose the method.

The user can now specify the Git merge method in the `auto-merge.json`. An example configuration:

```json
[
  {
    "match": {
      "dependency_name": "hashicorp/google",
      "update_type": "semver:minor"
    }
  },
  {
    "match": {
      "merge_method": "rebase",
      "dependency_name": "hashicorp/google-beta",
      "update_type": "semver:minor"
    }
  },
  {
    "match": {
      "merge_method": "squash",
      "package_ecosystem": "golang",
      "update_type": "semver:minor"
    }
  }
]
```

This uses all three kinds, `merge`, `squash` and `rebase`, since the first object `"hashicorp/google"` will be using the default merge method, `merge`.

When parsing the JSON in the step *Read configfile*, there is now the constant `mergeMethod` to be set, in addition to the boolean `shouldMerge` from before.

Both of these are written to the `$GITHUB_OUTPUT` variable for use in the next step.

A validation has been added to the final step to check whether the specified merge method is one of the three cases.