### PR TITLE
Print valideringsfeil etter terraform format

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -256,7 +256,7 @@ jobs:
 
         run: |
           echo 'Run format check' | tee -a $GITHUB_STEP_SUMMARY
-          terraform fmt -check -recursive -no-color || { echo "
+          terraform fmt -check -recursive -no-color -diff || { echo "
           FAILURE! The above files are not properly formatted.
           Run `terraform fmt` in $WORKING_DIRECTORY, commit the changed files and push to fix the issue" | tee -a $GITHUB_STEP_SUMMARY ; exit 1; }
 


### PR DESCRIPTION
Legger til flagg til `terraform fmt` slik at eventuelle formatteringsfeil blir printet ut. Slik er det lettere for bruker å faktisk rette de.

Fra https://developer.hashicorp.com/terraform/cli/commands/fmt:

> -diff	Displays the diffs of formatting changes.